### PR TITLE
Season 2023-2 January '24 Update

### DIFF
--- a/models/cars/advanced.csv
+++ b/models/cars/advanced.csv
@@ -13,13 +13,13 @@ Nano Rascal,50,2.25,0.99,0.8,nanorascal,FALSE
 Pegmound,55,2.57,2.5,0.8,phim_pegmound,FALSE
 Rice Ball,59.4,2.05,1.6,0.8,rice,FALSE
 Springtrap,55,2.8,1.2,0.8,rv2_buggy,FALSE
-WILL,57,2.47,1.65,0.8,phim_will,FALSE
 XTAR,61.3,2.41,2,0.8,nrf_xtar,FALSE
 Donnie TC,58,2.73,1.7,0.9,donnietc,FALSE
 DRJ-61,54.7,2.44,2,0.9,phim_drj-61,FALSE
 Glass Cannon,52.5,13.7,0.7,0.9,tcp_glass,FALSE
 Hyper XL,57.6,2.7,1.75,0.9,fd54hyper,FALSE
 Llag Sat,58.6,2.14,3.2,0.9,nrf_lag,FALSE
+WILL,57,2.47,1.65,0.9,phim_will,FALSE
 YNZ,58.7,2.16,1.7,0.9,nrf_ynz,FALSE
 Panga TC,59.9,2.13,1.8,1.0,tc2,TRUE
 Shocker,57.2,2.13,1.8,1.0,tc8,TRUE

--- a/models/cars/advanced.csv
+++ b/models/cars/advanced.csv
@@ -1,6 +1,7 @@
 name,speed,acc,weight,multiplier,folder_name,stock
 R6 Turbo,59.4,2.47,0.8,0.7,r5,TRUE
 Alice,54.7,2.31,1.4,0.7,alice,FALSE
+Glass Cannon,52.5,13.7,0.7,0.7,tcp_glass,FALSE
 Kyoki,56.8,2.73,1.4,0.7,kyoki,FALSE
 Neifion,56.5,2.39,1.7,0.7,fd154neifion,FALSE
 Top Tier,55,2.28,1.4,0.7,fd89top,FALSE
@@ -10,13 +11,12 @@ Camelia,58.8,2.78,1.71,0.8,camelia,FALSE
 Drawall,54.2,2.67,1.4,0.8,lib7a_spray,FALSE
 Le Pastel,56.8,2.14,2,0.8,fd110pastel,FALSE
 Nano Rascal,50,2.25,0.99,0.8,nanorascal,FALSE
-Pegmound,55,2.57,2.5,0.8,phim_pegmound,FALSE
 Rice Ball,59.4,2.05,1.6,0.8,rice,FALSE
 Springtrap,55,2.8,1.2,0.8,rv2_buggy,FALSE
 XTAR,61.3,2.41,2,0.8,nrf_xtar,FALSE
 Donnie TC,58,2.73,1.7,0.9,donnietc,FALSE
+Dust Shot,54.8,2.19,1.5,0.9,dustshot,FALSE
 DRJ-61,54.7,2.44,2,0.9,phim_drj-61,FALSE
-Glass Cannon,52.5,13.7,0.7,0.9,tcp_glass,FALSE
 Hyper XL,57.6,2.7,1.75,0.9,fd54hyper,FALSE
 Llag Sat,58.6,2.14,3.2,0.9,nrf_lag,FALSE
 WILL,57,2.47,1.65,0.9,phim_will,FALSE

--- a/models/cars/advanced.csv
+++ b/models/cars/advanced.csv
@@ -21,11 +21,11 @@ Glass Cannon,52.5,13.7,0.7,0.9,tcp_glass,FALSE
 Hyper XL,57.6,2.7,1.75,0.9,fd54hyper,FALSE
 Llag Sat,58.6,2.14,3.2,0.9,nrf_lag,FALSE
 YNZ,58.7,2.16,1.7,0.9,nrf_ynz,FALSE
-Panga TC,59.9,2.13,1.8,1,tc2,TRUE
-Shocker,57.2,2.13,1.8,1,tc8,TRUE
-Diamond,55.9,2.23,1.2,1,diamond,FALSE
-Metal Masher,53.4,2.59,2.7,1,jgp_metalmasher,FALSE
-Emperor,57.6,2.34,2,1.1,emperor,FALSE
+Panga TC,59.9,2.13,1.8,1.0,tc2,TRUE
+Shocker,57.2,2.13,1.8,1.0,tc8,TRUE
+Diamond,55.9,2.23,1.2,1.0,diamond,FALSE
+Emperor,57.6,2.34,2,1.0,emperor,FALSE
+Metal Masher,53.4,2.59,2.7,1.0,jgp_metalmasher,FALSE
 Flower Power,57.8,2.76,1.6,1.1,flowerpower2,FALSE
 Panther,62.9,2.18,1.65,1.1,panthergto,FALSE
 BossVolt,57.4,2.16,3.5,1.2,bossvolt,TRUE

--- a/models/cars/amateur.csv
+++ b/models/cars/amateur.csv
@@ -1,11 +1,11 @@
 name,speed,acc,weight,multiplier,folder_name,stock
 RC San,53.3,3.17,1,0.7,dino,TRUE
 Aquasonic,55.1,2.42,1.4,0.7,tc4,TRUE
-Dust Shot,54.1,2.2,1.5,0.7,dustshot,FALSE
 Honeybee,54.4,2.31,1.5,0.7,honey,FALSE
+Outraga,53.8,2.42,1.35,0.7,fd46rage,FALSE
 Rad Signal,52.4,2.64,1.2,0.7,tcp_doh,FALSE
 RC Halo,52.9,2.19,1.9,0.7,tcp_homage,FALSE
-Starway,52,2.8,1.5,0.7,lib7b_starway,FALSE
+Smokie,58.2,2.41,1.6,0.7,smokie,FALSE
 Vixen,51.8,2.47,1.5,0.7,tx9vix,FALSE
 LA 54,52,2.52,1.2,0.8,tc12,TRUE
 Matra XL,55.8,2.12,1.4,0.8,tc10,TRUE

--- a/models/cars/amateur.csv
+++ b/models/cars/amateur.csv
@@ -29,8 +29,8 @@ Kyarus,52.2,3.15,1.3,1.0,kyarus,FALSE
 Phantum,55.2,1.88,1.6,1.0,phantum,FALSE
 Reddlum,53.4,2.9,1.8,1.0,reddlum,FALSE
 Road King,50.1,3.13,2.8,1.0,roadking,FALSE
-Six Shooter,52.1,2.92,1.94,1.0,sixshooter,FALSE
 Slim,52.3,2.27,1.3,1.0,lib16c_slim,FALSE
 Queen Bee,52.3,2.33,1.9,1.2,tcp_drifter,FALSE
+Six Shooter,52.1,2.92,1.94,1.2,sixshooter,FALSE
 RC Phink,49.8,2.28,1.6,1.4,jg6rc,TRUE
 Genghis Kar,56.5,1.66,2,1.6,gencar,TRUE

--- a/models/cars/amateur.csv
+++ b/models/cars/amateur.csv
@@ -24,13 +24,13 @@ Stonemason,55,2,2.3,0.9,rip,FALSE
 Strax,50.4,2.58,1.4,0.9,strax,FALSE
 The Rook,55.3,1.93,1.3,0.9,tcp_rook,FALSE
 X-6 Nitro,51.8,2.3,1.6,0.9,jgp_x6,FALSE
-Mouse,54.7,2.9,2.3,1,mouse,TRUE
-Kyarus,52.2,3.15,1.3,1,kyarus,FALSE
-Phantum,55.2,1.88,1.6,1,phantum,FALSE
-Reddlum,53.4,2.9,1.8,1,reddlum,FALSE
-Road King,50.1,3.13,2.8,1,roadking,FALSE
-Six Shooter,52.1,2.92,1.94,1,sixshooter,FALSE
-Slim,52.3,2.27,1.3,1,lib16c_slim,FALSE
+Mouse,54.7,2.9,2.3,1.0,mouse,TRUE
+Kyarus,52.2,3.15,1.3,1.0,kyarus,FALSE
+Phantum,55.2,1.88,1.6,1.0,phantum,FALSE
+Reddlum,53.4,2.9,1.8,1.0,reddlum,FALSE
+Road King,50.1,3.13,2.8,1.0,roadking,FALSE
+Six Shooter,52.1,2.92,1.94,1.0,sixshooter,FALSE
+Slim,52.3,2.27,1.3,1.0,lib16c_slim,FALSE
 Queen Bee,52.3,2.33,1.9,1.2,tcp_drifter,FALSE
 RC Phink,49.8,2.28,1.6,1.4,jg6rc,TRUE
 Genghis Kar,56.5,1.66,2,1.6,gencar,TRUE

--- a/models/cars/pro.csv
+++ b/models/cars/pro.csv
@@ -15,8 +15,6 @@ Puma,64.5,4.14,1.8,0.8,nrf_puma,FALSE
 Wattage,65.5,3.21,1.8,0.8,tcp_watt,FALSE
 Humma,64,3.45,2,0.9,sugo,TRUE
 Steezy,66,3.07,1.7,0.9,steezy,FALSE
-Tegelhus,71.2,2.31,2.7,0.9,tigel,FALSE
-Truckenstein,67.4,2.71,2.8,0.9,gtc_truckenstein,FALSE
 Y Force,67.2,2.73,2,0.9,fd158yforce,FALSE
 Acclaim F1,66.8,3.66,1.0,1.0,acclaimf1,FALSE
 Karen,65.2,2.86,1.8,1.0,phim_jgkaren,FALSE
@@ -27,6 +25,8 @@ Wildstar,66.3,3.6,1,1.0,wildstar,FALSE
 Patriot,73.7,5.04,1.9,1.1,patriot,FALSE
 Toro GT84,70.4,2.92,1.5,1.1,gt84,FALSE
 Sir Gleam,67.4,4.45,1,1.2,gleam,FALSE
+Tegelhus,71.2,2.31,2.7,1.2,tigel,FALSE
+Truckenstein,67.4,2.71,2.8,1.2,gtc_truckenstein,FALSE
 RC Bulldog,70.5,2.81,5,1.4,bulldog,FALSE
 Star Oil,64.5,2.81,2.5,1.4,fd140oil,FALSE
 Superdriver,62.9,5.45,1.4,1.4,superdriver,FALSE

--- a/models/cars/rookie.csv
+++ b/models/cars/rookie.csv
@@ -25,10 +25,10 @@ Nesbitt,53.5,1.81,1.5,0.9,nesbitt,FALSE
 Piccino,50.1,3.11,0.85,0.9,midgetii,FALSE
 Rebound 4X4,53.8,2.25,1.5,0.9,rebound,FALSE
 Gunior,51,2.67,1.3,1.0,fd114gunior,FALSE
+Toukka 4x4,49.1,2.47,2.2,1.0,toukka,FALSE
 Get Air,51.7,3.31,2.7,1.1,getair,FALSE
 Rouge,52,2.57,1.2,1.1,fd25sporty,FALSE
 Super Wheat,52.4,1.86,2.4,1.1,swheat,FALSE
-Toukka 4x4,49.1,2.47,2.2,1.1,toukka,FALSE
 Dust Mite,50.5,1.98,1.2,1.2,mite,TRUE
 HSF-1,48.4,2.29,1.42,1.4,hsf1,FALSE
 Phat Slug,50.8,1.41,2.5,1.7,phat,TRUE

--- a/models/cars/rookie.csv
+++ b/models/cars/rookie.csv
@@ -28,9 +28,9 @@ Gunior,51,2.67,1.3,1.0,fd114gunior,FALSE
 Get Air,51.7,3.31,2.7,1.1,getair,FALSE
 Rouge,52,2.57,1.2,1.1,fd25sporty,FALSE
 Super Wheat,52.4,1.86,2.4,1.1,swheat,FALSE
+Toukka 4x4,49.1,2.47,2.2,1.1,toukka,FALSE
 Dust Mite,50.5,1.98,1.2,1.2,mite,TRUE
 HSF-1,48.4,2.29,1.42,1.4,hsf1,FALSE
-Toukka 4x4,49.1,2.47,2.2,1.2,toukka,FALSE
 Phat Slug,50.8,1.41,2.5,1.7,phat,TRUE
 Shiawase,41.6,1,5,2.0,shiawasecrimsonsolace,FALSE
 Creeki Leeki,49.9,2.16,1.2,3.0,gtcnd_creekileeki,FALSE

--- a/models/cars/semi-pro.csv
+++ b/models/cars/semi-pro.csv
@@ -13,6 +13,7 @@ Mambra,58.6,4.37,1.6,0.8,mambra,FALSE
 RC-Erra,59.9,2.53,1.6,0.8,cera,FALSE
 Touga,65.7,3.08,2,0.8,touga,FALSE
 Victoria,57.4,2.65,1.7,0.8,phim_victoria,FALSE
+5TP,62.2,3.04,2.5,0.9,jgp_5tp,FALSE
 Chilla,62,2.22,1.4,0.9,tcp_chilla,FALSE
 Ducktail,60.3,2.46,2,0.9,phim_ducktail,FALSE
 M4 Dirtmaster,59.2,2.45,1.9,0.9,fd23m4,FALSE
@@ -21,12 +22,11 @@ Runner 2000,59.8,3.18,1.32,0.9,nrf_runner,FALSE
 Sasquatch,61.4,2.47,3,0.9,sasquatch,FALSE
 Speed Balancer,62.1,3.22,1.8,0.9,speedbalancer,FALSE
 RG1,57.9,2.82,1.4,1.0,tc7,TRUE
-Otaku-D,61.3,3.68,1.7,1.0,phim_sileighty,FALSE
 Trundle Buster,61.5,2.92,4,1.0,nm_trundle,FALSE
-5TP,62.2,3.04,2.5,1.1,jgp_5tp,FALSE
-Sidepod,63.9,2.25,1.2,1.1,sidepod,FALSE
 Ballista,62.5,4.18,2.0,1.2,ballista,FALSE
+Otaku-D,61.3,3.68,1.7,1.2,phim_sileighty,FALSE
 Pemto,65.7,2.58,1.5,1.2,pemto,FALSE
+Sidepod,63.9,2.25,1.2,1.3,sidepod,FALSE
 Big Load,61.5,1.94,3.7,1.5,jgp_bigload,FALSE
 Pest Control,66.6,1.66,2,2.3,tc3,TRUE
 Pole Poz,60.5,2.53,1.7,2.3,fone,TRUE

--- a/models/cars/super-pro.csv
+++ b/models/cars/super-pro.csv
@@ -2,7 +2,6 @@ name,speed,acc,weight,multiplier,folder_name,stock
 Armand,69.2,4.17,1.45,0.7,armando,FALSE
 Endo,71.2,4.75,2.7,0.7,nrf_endo,FALSE
 Phantera ART,72.9,3.59,1.75,0.7,phanteraart,FALSE
-Powerpython,70.3,3.53,2,0.7,tcp_python,FALSE
 Raven,70.4,3.5,2.5,0.7,raven,FALSE
 Revolution 12,71.4,4.48,1.8,0.7,gtc_revolution12,FALSE
 Wyvern,70.7,3.81,1.8,0.7,tcp_wyvern,FALSE
@@ -11,6 +10,7 @@ Cambold R,71.1,3.69,1.4,0.8,camboldr,FALSE
 Commandine,65.1,3.44,2,0.8,fd101command,FALSE
 Daemmon,74.6,3.86,1.85,0.8,daemmon,FALSE
 La Rossa,73,4.14,2,0.8,fd94rossa,FALSE
+Powerpython,70.3,3.53,2,0.8,tcp_python,FALSE
 RVRC,70.3,4,2,0.8,rvrc,FALSE
 Prototype FX77,65.3,2.98,1.2,0.8,fd_s9,FALSE
 Spedion,69.5,4.13,2,0.8,phim_jgspedion,FALSE

--- a/models/cars/super-pro.csv
+++ b/models/cars/super-pro.csv
@@ -11,8 +11,8 @@ Commandine,65.1,3.44,2,0.8,fd101command,FALSE
 Daemmon,74.6,3.86,1.85,0.8,daemmon,FALSE
 La Rossa,73,4.14,2,0.8,fd94rossa,FALSE
 Powerpython,70.3,3.53,2,0.8,tcp_python,FALSE
-RVRC,70.3,4,2,0.8,rvrc,FALSE
 Prototype FX77,65.3,2.98,1.2,0.8,fd_s9,FALSE
+RVRC,70.3,4,2,0.8,rvrc,FALSE
 Spedion,69.5,4.13,2,0.8,phim_jgspedion,FALSE
 Starmac,68.7,3.54,1.8,0.8,starmac,FALSE
 Tesseract,71.5,4.02,2,0.8,fd_s7,FALSE


### PR DESCRIPTION
- The following cars have been balanced:

**Rookie**
Toukka 4x4 (1.2 -> 1.1)

**Advanced**
WILL (0.8 -> 0.9)
Emperor (1.1 -> 1.0)

**Semi-Pro**
5TP (1.1 -> 0.9)
Otaku-D (1.0 -> 1.2)
Sidepod (1.1 -> 1.3)

**Pro**
Tegelhus (0.9 -> 1.2)
Truckenstein (0.9 -> 1.2)

**Super Pro**
Powerpython (0.7 -> 0.8)

- Fixed typos on Amateur and Advanced cars with 1.0 multiplier.