### PR TITLE
Update track models for Season 2024-1

### DIFF
--- a/models/cars/rookie.csv
+++ b/models/cars/rookie.csv
@@ -1,36 +1,33 @@
-name,speed,acc,weight,multiplier,folder_name,stock
-RC Bandit,51.7,2.09,1.2,0.7,rc,TRUE
-Dr. Grudge,51.3,2.54,1.4,0.7,beatall,TRUE
-Sprinter XL,50.7,3.2,0.9,0.7,tc6,TRUE
-E-Razr,47.2,3.1,1.1,0.7,erazer,FALSE
-Hurricane,48.8,2.3,1.5,0.7,hurri,FALSE
-Iso-77A,48.8,3.03,1.33,0.7,iso77,FALSE
-Kanberra Kruiser,50.8,2.38,1,0.7,kkruise,FALSE
-Harvester,47.9,2.32,1.7,0.8,mud,TRUE
-Albatross GT,48.5,2.36,1.4,0.8,albatrossgt,FALSE
-Bed Bug,52.1,1.98,1.2,0.8,bedbug2,FALSE
-Condor GRV,51.5,2.73,1.5,0.8,condorgrv,FALSE
-El Gekko,51.3,2.01,1.2,0.8,gekko,FALSE
-Funk Flea,51.0,2.77,1.14,0.8,flea,FALSE
-High-Rod,49,2.17,1.9,0.8,rod,FALSE
-Hot Spot,51.3,2.36,1,0.8,hs,FALSE
-LR 64,54.1,1.55,1.7,0.8,fd64lost,FALSE
-Panorama,50.6,2.3,1.35,0.8,fd50pano,FALSE
-Road Star,50.3,2.49,0.8,0.8,roadstar,FALSE
-Col. Moss,52.8,2.17,1.5,0.9,moss,TRUE
-Volken Turbo,49.5,2.24,1.6,0.9,volken,TRUE
-BigVolt,52.8,2.36,2.3,0.9,bigvolt,TRUE
-Ferrada,54.1,2.06,1.2,0.9,ferrada,FALSE
-Nesbitt,53.5,1.81,1.5,0.9,nesbitt,FALSE
-Rebound 4X4,53.8,2.25,1.5,0.9,rebound,FALSE
-Gunior,51,2.67,1.3,1.0,fd114gunior,FALSE
-Toukka 4x4,49.1,2.47,2.2,1.0,toukka,FALSE
-Get Air,51.7,3.31,2.7,1.1,getair,FALSE
-Rouge,52,2.57,1.2,1.1,fd25sporty,FALSE
-Super Wheat,52.4,1.86,2.4,1.1,swheat,FALSE
-Dust Mite,50.5,1.98,1.2,1.2,mite,TRUE
-Piccino,50.1,3.11,0.85,1.2,midgetii,FALSE
-HSF-1,48.4,2.29,1.42,1.4,hsf1,FALSE
-Phat Slug,50.8,1.41,2.5,1.7,phat,TRUE
-Shiawase,41.6,1,5,2.0,shiawasecrimsonsolace,FALSE
-Creeki Leeki,49.9,2.16,1.2,3.0,gtcnd_creekileeki,FALSE
+name,speed,acc,weight,multiplier,folder_name,main_author,stock
+RC Bandit,51.7,2.09,1.2,0.7,rc,Acclaim Studios London,TRUE
+Dr. Grudge,51.3,2.54,1.4,0.7,beatall,Acclaim Studios London,TRUE
+Sprinter XL,50.7,3.2,0.9,0.7,tc6,Acclaim Studios London,TRUE
+Cheat Code Central,49.6,1.95,1.6,0.7,phim_cheatcc,Phimeek,FALSE
+E-Razr,47.2,3.1,1.1,0.7,erazer,MightyCucumber,FALSE
+Hurricane,48.8,2.3,1.5,0.7,hurri,MightyCucumber,FALSE
+Harvester,47.9,2.32,1.7,0.8,mud,Acclaim Studios London,TRUE
+Albatross GT,48.5,2.36,1.4,0.8,albatrossgt,BloodBTF,FALSE
+Condor GRV,51.5,2.73,1.5,0.8,condorgrv,TTDriver,FALSE
+Funk Flea,51.0,2.77,1.14,0.8,flea,MightyCucumber,FALSE
+High-Rod,49,2.17,1.9,0.8,rod,MightyCucumber,FALSE
+LR 64,54.1,1.55,1.7,0.8,fd64lost,Xarc,FALSE
+Mr Bedtime,54.9,1.94,1.8,0.8,mrbedtime,Zeino,FALSE
+Panorama,50.6,2.3,1.35,0.8,fd50pano,Xarc,FALSE
+Road Star,50.3,2.49,0.8,0.8,roadstar,Trixed,FALSE
+Col. Moss,52.8,2.17,1.5,0.9,moss,Acclaim Studios London,TRUE
+Volken Turbo,49.5,2.24,1.6,0.9,volken,Acclaim Studios London,TRUE
+BigVolt,52.8,2.36,2.3,0.9,bigvolt,Acclaim Studios London,TRUE
+Beeble,52.3,2.38,1.2,0.9,beeble,MightyCucumber,FALSE
+Ferrada,54.1,2.06,1.2,0.9,ferrada,TTDriver,FALSE
+Nesbitt,53.5,1.81,1.5,0.9,nesbitt,Skarma,FALSE
+Rebound 4X4,53.8,2.25,1.5,0.9,rebound,Paperman,FALSE
+Turbo Katto,46.8,2.48,4,0.9,katto,burner94,FALSE
+Toukka 4x4,49.1,2.47,2.2,1.0,toukka,Zeino,FALSE
+Get Air,51.7,3.31,2.7,1.1,getair,MightyCucumber,FALSE
+Rouge,52,2.57,1.2,1.1,fd25sporty,Xarc,FALSE
+Toon Zoom,49.2,5.27,0.5,1.1,tzoom,MightyCucumber,FALSE
+Dust Mite,50.5,1.98,1.2,1.2,mite,Acclaim Studios London,TRUE
+Piccino,50.1,3.11,0.85,1.2,midgetii,NotDaijoubu,FALSE
+Phat Slug,50.8,1.41,2.5,1.7,phat,Acclaim Studios London,TRUE
+Shiawase,41.6,1,5,2.0,shiawasecrimsonsolace,shara--,FALSE
+Creeki Leeki,49.9,2.16,1.2,3.0,gtcnd_creekileeki,Ghosterino,FALSE

--- a/models/cars/rookie.csv
+++ b/models/cars/rookie.csv
@@ -1,33 +1,36 @@
-name,speed,acc,weight,multiplier,folder_name,main_author,stock
-RC Bandit,51.7,2.09,1.2,0.7,rc,Acclaim Studios London,TRUE
-Dr. Grudge,51.3,2.54,1.4,0.7,beatall,Acclaim Studios London,TRUE
-Sprinter XL,50.7,3.2,0.9,0.7,tc6,Acclaim Studios London,TRUE
-Cheat Code Central,49.6,1.95,1.6,0.7,phim_cheatcc,Phimeek,FALSE
-E-Razr,47.2,3.1,1.1,0.7,erazer,MightyCucumber,FALSE
-Hurricane,48.8,2.3,1.5,0.7,hurri,MightyCucumber,FALSE
-Harvester,47.9,2.32,1.7,0.8,mud,Acclaim Studios London,TRUE
-Albatross GT,48.5,2.36,1.4,0.8,albatrossgt,BloodBTF,FALSE
-Condor GRV,51.5,2.73,1.5,0.8,condorgrv,TTDriver,FALSE
-Funk Flea,51.0,2.77,1.14,0.8,flea,MightyCucumber,FALSE
-High-Rod,49,2.17,1.9,0.8,rod,MightyCucumber,FALSE
-LR 64,54.1,1.55,1.7,0.8,fd64lost,Xarc,FALSE
-Mr Bedtime,54.9,1.94,1.8,0.8,mrbedtime,Zeino,FALSE
-Panorama,50.6,2.3,1.35,0.8,fd50pano,Xarc,FALSE
-Road Star,50.3,2.49,0.8,0.8,roadstar,Trixed,FALSE
-Col. Moss,52.8,2.17,1.5,0.9,moss,Acclaim Studios London,TRUE
-Volken Turbo,49.5,2.24,1.6,0.9,volken,Acclaim Studios London,TRUE
-BigVolt,52.8,2.36,2.3,0.9,bigvolt,Acclaim Studios London,TRUE
-Beeble,52.3,2.38,1.2,0.9,beeble,MightyCucumber,FALSE
-Ferrada,54.1,2.06,1.2,0.9,ferrada,TTDriver,FALSE
-Nesbitt,53.5,1.81,1.5,0.9,nesbitt,Skarma,FALSE
-Rebound 4X4,53.8,2.25,1.5,0.9,rebound,Paperman,FALSE
-Turbo Katto,46.8,2.48,4,0.9,katto,burner94,FALSE
-Toukka 4x4,49.1,2.47,2.2,1.0,toukka,Zeino,FALSE
-Get Air,51.7,3.31,2.7,1.1,getair,MightyCucumber,FALSE
-Rouge,52,2.57,1.2,1.1,fd25sporty,Xarc,FALSE
-Toon Zoom,49.2,5.27,0.5,1.1,tzoom,MightyCucumber,FALSE
-Dust Mite,50.5,1.98,1.2,1.2,mite,Acclaim Studios London,TRUE
-Piccino,50.1,3.11,0.85,1.2,midgetii,NotDaijoubu,FALSE
-Phat Slug,50.8,1.41,2.5,1.7,phat,Acclaim Studios London,TRUE
-Shiawase,41.6,1,5,2.0,shiawasecrimsonsolace,shara--,FALSE
-Creeki Leeki,49.9,2.16,1.2,3.0,gtcnd_creekileeki,Ghosterino,FALSE
+name,speed,acc,weight,multiplier,folder_name,stock
+RC Bandit,51.7,2.09,1.2,0.7,rc,TRUE
+Dr. Grudge,51.3,2.54,1.4,0.7,beatall,TRUE
+Sprinter XL,50.7,3.2,0.9,0.7,tc6,TRUE
+E-Razr,47.2,3.1,1.1,0.7,erazer,FALSE
+Hurricane,48.8,2.3,1.5,0.7,hurri,FALSE
+Iso-77A,48.8,3.03,1.33,0.7,iso77,FALSE
+Kanberra Kruiser,50.8,2.38,1,0.7,kkruise,FALSE
+Harvester,47.9,2.32,1.7,0.8,mud,TRUE
+Albatross GT,48.5,2.36,1.4,0.8,albatrossgt,FALSE
+Bed Bug,52.1,1.98,1.2,0.8,bedbug2,FALSE
+Condor GRV,51.5,2.73,1.5,0.8,condorgrv,FALSE
+El Gekko,51.3,2.01,1.2,0.8,gekko,FALSE
+Funk Flea,51.0,2.77,1.14,0.8,flea,FALSE
+High-Rod,49,2.17,1.9,0.8,rod,FALSE
+Hot Spot,51.3,2.36,1,0.8,hs,FALSE
+LR 64,54.1,1.55,1.7,0.8,fd64lost,FALSE
+Panorama,50.6,2.3,1.35,0.8,fd50pano,FALSE
+Road Star,50.3,2.49,0.8,0.8,roadstar,FALSE
+Col. Moss,52.8,2.17,1.5,0.9,moss,TRUE
+Volken Turbo,49.5,2.24,1.6,0.9,volken,TRUE
+BigVolt,52.8,2.36,2.3,0.9,bigvolt,TRUE
+Ferrada,54.1,2.06,1.2,0.9,ferrada,FALSE
+Nesbitt,53.5,1.81,1.5,0.9,nesbitt,FALSE
+Rebound 4X4,53.8,2.25,1.5,0.9,rebound,FALSE
+Gunior,51,2.67,1.3,1.0,fd114gunior,FALSE
+Toukka 4x4,49.1,2.47,2.2,1.0,toukka,FALSE
+Get Air,51.7,3.31,2.7,1.1,getair,FALSE
+Rouge,52,2.57,1.2,1.1,fd25sporty,FALSE
+Super Wheat,52.4,1.86,2.4,1.1,swheat,FALSE
+Dust Mite,50.5,1.98,1.2,1.2,mite,TRUE
+Piccino,50.1,3.11,0.85,1.2,midgetii,FALSE
+HSF-1,48.4,2.29,1.42,1.4,hsf1,FALSE
+Phat Slug,50.8,1.41,2.5,1.7,phat,TRUE
+Shiawase,41.6,1,5,2.0,shiawasecrimsonsolace,FALSE
+Creeki Leeki,49.9,2.16,1.2,3.0,gtcnd_creekileeki,FALSE

--- a/models/tracks/tracks.csv
+++ b/models/tracks/tracks.csv
@@ -21,13 +21,14 @@ Game Room 2,GR2,2,635,fdt24arcade2,Xarc,FALSE,37
 Ghost Town 1,GT1,1,324,wild_west1,Acclaim Studios London,TRUE,22
 Ghost Town 2,GT2,3,490,wild_west2,Acclaim Studios London,TRUE,30
 Grisville,GV,3,648,ghetto,Allan1,FALSE,44
-Helios/Lunar,HL,-1,655,helios-lunar,Human,FALSE,42
+Helios/Lunar (RVA),HL,-1,655,helios-lunar,Human,FALSE,42
 HMS Invincible,HMS,1,621,hms_redux,MOH,FALSE,38
-Holiday Camp,HC,-1,1170,hcampal,Marv,FALSE,76
+Holiday Camp: California Edition,HC,-1,1170,hcampal,Marv,FALSE,76
 Home 1,HO1,0,237,home1,G_J,FALSE,13.8
 Home 2,HO2,2,489,home2,G_J,FALSE,27
 Hospital 1,HP1,2,623,hospital1,G_J,FALSE,35
 Hospital 2,HP2,2,399,hospital2,G_J,FALSE,26
+Hull Breach 3000 (RVA),HB3,3,508,breach3000_rva,Gorgonzola,FALSE,34
 Jailhouse Rock,JR,-1,729,jailhouse,Human,FALSE,45
 Kadish Sprint,KS,2,814,kadishs,Dyspro50,FALSE,56
 Library,LIB,3,570,library,CapitaineSZM,FALSE,45
@@ -40,7 +41,7 @@ Museum 1,M1,2,668,muse1,Acclaim Studios London,TRUE,46
 Museum 2,M2,0,600,muse2,Acclaim Studios London,TRUE,34
 Museum 3,M3,0,539,muse3,hilaire9,FALSE,40
 Museum EX,MX,3,970,fdt13xmuse,Xarc,FALSE,54
-Museum Unleashed,MU,2,1295,museun_rva,maxi,FALSE,75
+Museum Unleashed (RVA),MU,2,1295,museun_rva,maxi,FALSE,75
 Paper Town 1,PT1,1,350,papertown1,CapitaineSZM,FALSE,22
 PetroVolt,PV,3,948,petrol,Gabor,FALSE,50
 Port Limano 1,PL1,1,308,portlimano1,benderfan3124,FALSE,22
@@ -52,7 +53,7 @@ Rigs Highway,RH,2,671,pmt_highway,Paperman,FALSE,42
 Rooftop Chase: Redux,RCR,-1,605,roofchaseredux,r6te,FALSE,46
 Rooftops,RT,1,588,roof,Acclaim Studios London,TRUE,38
 Rooftops 1,RT1,3,717,roof1,G_J,FALSE,50
-RV Temple,RVT,-1,1116,rvt_rva,Antimorph,FALSE,75
+RV Temple (RVA),RVT,-1,1116,rvt_rva,Antimorph,FALSE,75
 Sakura,SKR,-1,752,sakura,Human,FALSE,45
 Santorini,SAN,0,500,santorini,Alexander,FALSE,28
 School's Out! 1,SO1,1,495,schoolslite,kiwi,FALSE,30

--- a/models/tracks/tracks.csv
+++ b/models/tracks/tracks.csv
@@ -72,7 +72,7 @@ Toy World 2,TW2,1,444,toy2,Acclaim Studios London,TRUE,28
 Toy World Mayhem,TWM,-1,465,toymayhem,Killer Wheels,FALSE,33
 Toys in the Hood 1,TH1,0,747,nhood1,Acclaim Studios London,TRUE,40
 Toys in the Hood 2,TH2,2,592,nhood2,Acclaim Studios London,TRUE,35
-Toys in the Hood 4,TH4,3,706,nhood4,Chris Johannsen,FALSE,40
+Toys in the Hood 4 (RVA),TH4,3,706,nhood4_rva,Chris Johannsen,FALSE,40
 ToySoldierz,TSZ,-1,454,toysoldierz,Skitch2,FALSE,34
 Toytanic 1,T1,2,742,ship1,Acclaim Studios London,TRUE,42
 Toytanic 2,T2,3,742,ship2,Acclaim Studios London,TRUE,42

--- a/models/tracks/tracks.csv
+++ b/models/tracks/tracks.csv
@@ -1,4 +1,4 @@
-name,short_name,difficulty,length,folder_name,main_author,stock,average_lap_time
+name,short_name,difficulty,length,folder_name,author,stock,average_lap_time
 Airport 1,AP1,2,612,fdt16airport1,Xarc,FALSE,35
 Aqueduct,AQU,2,426,aqueduct,hilarious6,FALSE,31
 Botanical Garden,BG,0,323,garden1,Acclaim Studios London,TRUE,22

--- a/models/tracks/tracks.csv
+++ b/models/tracks/tracks.csv
@@ -1,82 +1,81 @@
-name;short_name;difficulty;length;folder_name;main_author;stock;average_lap_time
-Airport 1;AP1;2;612;fdt16airport1;Xarc;FALSE;35
-Aqueduct;AQU;2;426;aqueduct;hilarious6;FALSE;31
-Botanical Garden;BG;0;323;garden1;Acclaim Studios London;TRUE;22
-Botanical Garden EX;BGX;2;807;fdt9xgarden;Xarc;FALSE;45
-Calaboq;CBQ;-1;512;calaboq;Gforce;FALSE;33
-Cardboard Castle;CC;0;426;pmt_box;Paperman;FALSE;26
-Casino RV;CAS;1;635;casinorv;CapitaineSZM;FALSE;42
-Castle 1;CT1;3;795;fdt21castle1;Xarc;FALSE;42
-Castle 2;CT2;3;715;fdt22castle2;Xarc;FALSE;41
-Desolate District 1;DD1;2;657;district;RV_Pure;FALSE;42
-Downtown 1;DT1;1;800;dtown1;G_J;FALSE;46
-Downtown 2;DT2;3;916;dtown2;G_J;FALSE;50
-Elementary 1;E1;0;374;elementary1;G_J;FALSE;27
-Elementary 2;E2;0;402;elementary2;G_J;FALSE;27
-Fairground 1;FG1;1;363;fair1;G_J;FALSE;24
-Fairground 2;FG2;3;766;fair2;G_J;FALSE;45
-Forest Mansion 2;FM2;1;478;ccastle2;Chris Johannsen;FALSE;33
-Game Room 1;GR1;1;417;fdt23arcade1;Xarc;FALSE;26
-Game Room 2;GR2;2;635;fdt24arcade2;Xarc;FALSE;37
-Ghost Town 1;GT1;1;324;wild_west1;Acclaim Studios London;TRUE;22
-Ghost Town 2;GT2;3;490;wild_west2;Acclaim Studios London;TRUE;30
-Grisville;GV;3;648;ghetto;Allan1;FALSE;44
-Helios/Lunar;HL;-1;655;helios-lunar;Human;FALSE;42
-HMS Invincible;HMS;1;621;hms_redux;MOH;FALSE;38
-Holiday Camp;HC;-1;1170;hcampal;Marv;FALSE;76
-Home 1;HO1;0;237;home1;G_J;FALSE;13.8
-Home 2;HO2;2;489;home2;G_J;FALSE;27
-Hospital 1;HP1;2;623;hospital1;G_J;FALSE;35
-Hospital 2;HP2;2;399;hospital2;G_J;FALSE;26
-Jailhouse Rock;JR;-1;729;jailhouse;Human;FALSE;45
-Kadish Sprint;KS;2;814;kadishs;Dyspro50;FALSE;56
-Library;LIB;3;570;library;CapitaineSZM;FALSE;45
-Market Mayhem;MM;1;448;marketmayhem;BloodBTF;FALSE;26
-Metro-Volt;MV;-1;649;metrovolt;Human;FALSE;42
-MineZcraft;MZC;-1;438;minezcraft;Zach;FALSE;32
-Moon Dawn;MD;3;1418;dome3;Allan1;FALSE;92
-Motel in the Hood;MIH;-1;325;motelinhood;MirkoGT97;FALSE;31
-Museum 1;M1;2;668;muse1;Acclaim Studios London;TRUE;46
-Museum 2;M2;0;600;muse2;Acclaim Studios London;TRUE;34
-Museum 3;M3;0;539;muse3;hilaire9;FALSE;40
-Museum EX;MX;3;970;fdt13xmuse;Xarc;FALSE;54
-Museum Unleashed;MU;2;1295;museun_rva;maxi;FALSE;75
-Paper Town 1;PT1;1;350;papertown1;CapitaineSZM;FALSE;22
-PetroVolt;PV;3;948;petrol;Gabor;FALSE;50
-Port Limano 1;PL1;1;308;portlimano1;benderfan3124;FALSE;22
-Port Limano 2;PL2;2;616;portlimano2;benderfan3124;FALSE;38
-Port Limano EX;PLX;3;819;portlimanoex;benderfan3124;FALSE;43
-Quake!;Q!;3;843;quake;Gabor;FALSE;49
-Ranch;RAN;2;950;ranch;Marv;FALSE;72
-Rigs Highway;RH;2;671;pmt_highway;Paperman;FALSE;42
-Rooftop Chase: Redux;RCR;-1;605;roofchaseredux;r6te;FALSE;46
-Rooftops;RT;1;588;roof;Acclaim Studios London;TRUE;38
-Rooftops 1;RT1;3;717;roof1;G_J;FALSE;50
-RV Temple;RVT;-1;1116;rvt_rva;Antimorph;FALSE;75
-Sakura;SKR;-1;752;sakura;Human;FALSE;45
-Santorini;SAN;0;500;santorini;Alexander;FALSE;28
-School's Out! 1;SO1;1;495;schoolslite;kiwi;FALSE;30
-School's Out! 2;SO2;3;1545;schools;kiwi;FALSE;106
-Skating Toys Redux;STR;3;1011;skatoysred;Zorbah;FALSE;71
-Spa-Volt 1;SV1;3;595;spavolt1;kiwi;FALSE;44
-Spa-Volt 2;SV2;3;532;spavolt2;kiwi;FALSE;35
-Spring Visit;SV;0;560;pmt_springvst;Paperman;FALSE;35
-StadVolt;STV;2;571;stadvolt;L17;FALSE;32
-Subway 2;SW2;1;937;subway2;CapitaineSZM;FALSE;65
-SuperMarket 1;SM1;3;502;market1;Acclaim Studios London;TRUE;32
-SuperMarket 2;SM2;0;301;market2;Acclaim Studios London;TRUE;17
-The Great Silence;TGS;3;583;winterwest;kiwi;FALSE;42
-Toy World 1;TW1;1;354;toylite;Acclaim Studios London;TRUE;22
-Toy World 2;TW2;1;444;toy2;Acclaim Studios London;TRUE;28
-Toy World Mayhem;TWM;-1;465;toymayhem;Killer Wheels;FALSE;33
-Toys in the Hood 1;TH1;0;747;nhood1;Acclaim Studios London;TRUE;40
-Toys in the Hood 2;TH2;2;592;nhood2;Acclaim Studios London;TRUE;35
-Toys in the Hood 4;TH4;3;706;nhood4;Chris Johannsen;FALSE;40
-ToySoldierz;TSZ;-1;454;toysoldierz;Skitch2;FALSE;34
-Toytanic 1;T1;2;742;ship1;Acclaim Studios London;TRUE;42
-Toytanic 2;T2;3;742;ship2;Acclaim Studios London;TRUE;42
-User-Deli: XL;DEL;3;390;user-delixl;BGM;FALSE;39
-Venice;VN;3;617;venice;Gabor;FALSE;40
-White Rose Chapel;WRC;-1;653;whiterose;hilaire9;FALSE;45
-Wladyslawowo;WLW;2;619;wladyslawowo;hilarious6;FALSE;38
-;;;;;;;
+name,short_name,difficulty,length,folder_name,main_author,stock,average_lap_time
+Airport 1,AP1,2,612,fdt16airport1,Xarc,FALSE,35
+Aqueduct,AQU,2,426,aqueduct,hilarious6,FALSE,31
+Botanical Garden,BG,0,323,garden1,Acclaim Studios London,TRUE,22
+Botanical Garden EX,BGX,2,807,fdt9xgarden,Xarc,FALSE,45
+Calaboq,CBQ,-1,512,calaboq,Gforce,FALSE,33
+Cardboard Castle,CC,0,426,pmt_box,Paperman,FALSE,26
+Casino RV,CAS,1,635,casinorv,CapitaineSZM,FALSE,42
+Castle 1,CT1,3,795,fdt21castle1,Xarc,FALSE,42
+Castle 2,CT2,3,715,fdt22castle2,Xarc,FALSE,41
+Desolate District 1,DD1,2,657,district,RV_Pure,FALSE,42
+Downtown 1,DT1,1,800,dtown1,G_J,FALSE,46
+Downtown 2,DT2,3,916,dtown2,G_J,FALSE,50
+Elementary 1,E1,0,374,elementary1,G_J,FALSE,27
+Elementary 2,E2,0,402,elementary2,G_J,FALSE,27
+Fairground 1,FG1,1,363,fair1,G_J,FALSE,24
+Fairground 2,FG2,3,766,fair2,G_J,FALSE,45
+Forest Mansion 2,FM2,1,478,ccastle2,Chris Johannsen,FALSE,33
+Game Room 1,GR1,1,417,fdt23arcade1,Xarc,FALSE,26
+Game Room 2,GR2,2,635,fdt24arcade2,Xarc,FALSE,37
+Ghost Town 1,GT1,1,324,wild_west1,Acclaim Studios London,TRUE,22
+Ghost Town 2,GT2,3,490,wild_west2,Acclaim Studios London,TRUE,30
+Grisville,GV,3,648,ghetto,Allan1,FALSE,44
+Helios/Lunar,HL,-1,655,helios-lunar,Human,FALSE,42
+HMS Invincible,HMS,1,621,hms_redux,MOH,FALSE,38
+Holiday Camp,HC,-1,1170,hcampal,Marv,FALSE,76
+Home 1,HO1,0,237,home1,G_J,FALSE,13.8
+Home 2,HO2,2,489,home2,G_J,FALSE,27
+Hospital 1,HP1,2,623,hospital1,G_J,FALSE,35
+Hospital 2,HP2,2,399,hospital2,G_J,FALSE,26
+Jailhouse Rock,JR,-1,729,jailhouse,Human,FALSE,45
+Kadish Sprint,KS,2,814,kadishs,Dyspro50,FALSE,56
+Library,LIB,3,570,library,CapitaineSZM,FALSE,45
+Market Mayhem,MM,1,448,marketmayhem,BloodBTF,FALSE,26
+Metro-Volt,MV,-1,649,metrovolt,Human,FALSE,42
+MineZcraft,MZC,-1,438,minezcraft,Zach,FALSE,32
+Moon Dawn,MD,3,1418,dome3,Allan1,FALSE,92
+Motel in the Hood,MIH,-1,325,motelinhood,MirkoGT97,FALSE,31
+Museum 1,M1,2,668,muse1,Acclaim Studios London,TRUE,46
+Museum 2,M2,0,600,muse2,Acclaim Studios London,TRUE,34
+Museum 3,M3,0,539,muse3,hilaire9,FALSE,40
+Museum EX,MX,3,970,fdt13xmuse,Xarc,FALSE,54
+Museum Unleashed,MU,2,1295,museun_rva,maxi,FALSE,75
+Paper Town 1,PT1,1,350,papertown1,CapitaineSZM,FALSE,22
+PetroVolt,PV,3,948,petrol,Gabor,FALSE,50
+Port Limano 1,PL1,1,308,portlimano1,benderfan3124,FALSE,22
+Port Limano 2,PL2,2,616,portlimano2,benderfan3124,FALSE,38
+Port Limano EX,PLX,3,819,portlimanoex,benderfan3124,FALSE,43
+Quake!,Q!,3,843,quake,Gabor,FALSE,49
+Ranch,RAN,2,950,ranch,Marv,FALSE,72
+Rigs Highway,RH,2,671,pmt_highway,Paperman,FALSE,42
+Rooftop Chase: Redux,RCR,-1,605,roofchaseredux,r6te,FALSE,46
+Rooftops,RT,1,588,roof,Acclaim Studios London,TRUE,38
+Rooftops 1,RT1,3,717,roof1,G_J,FALSE,50
+RV Temple,RVT,-1,1116,rvt_rva,Antimorph,FALSE,75
+Sakura,SKR,-1,752,sakura,Human,FALSE,45
+Santorini,SAN,0,500,santorini,Alexander,FALSE,28
+School's Out! 1,SO1,1,495,schoolslite,kiwi,FALSE,30
+School's Out! 2,SO2,3,1545,schools,kiwi,FALSE,106
+Skating Toys Redux,STR,3,1011,skatoysred,Zorbah,FALSE,71
+Spa-Volt 1,SV1,3,595,spavolt1,kiwi,FALSE,44
+Spa-Volt 2,SV2,3,532,spavolt2,kiwi,FALSE,35
+Spring Visit,SV,0,560,pmt_springvst,Paperman,FALSE,35
+StadVolt,STV,2,571,stadvolt,L17,FALSE,32
+Subway 2,SW2,1,937,subway2,CapitaineSZM,FALSE,65
+SuperMarket 1,SM1,3,502,market1,Acclaim Studios London,TRUE,32
+SuperMarket 2,SM2,0,301,market2,Acclaim Studios London,TRUE,17
+The Great Silence,TGS,3,583,winterwest,kiwi,FALSE,42
+Toy World 1,TW1,1,354,toylite,Acclaim Studios London,TRUE,22
+Toy World 2,TW2,1,444,toy2,Acclaim Studios London,TRUE,28
+Toy World Mayhem,TWM,-1,465,toymayhem,Killer Wheels,FALSE,33
+Toys in the Hood 1,TH1,0,747,nhood1,Acclaim Studios London,TRUE,40
+Toys in the Hood 2,TH2,2,592,nhood2,Acclaim Studios London,TRUE,35
+Toys in the Hood 4,TH4,3,706,nhood4,Chris Johannsen,FALSE,40
+ToySoldierz,TSZ,-1,454,toysoldierz,Skitch2,FALSE,34
+Toytanic 1,T1,2,742,ship1,Acclaim Studios London,TRUE,42
+Toytanic 2,T2,3,742,ship2,Acclaim Studios London,TRUE,42
+User-Deli: XL,DEL,3,390,user-delixl,BGM,FALSE,39
+Venice,VN,3,617,venice,Gabor,FALSE,40
+White Rose Chapel,WRC,-1,653,whiterose,hilaire9,FALSE,45
+Wladyslawowo,WLW,2,619,wladyslawowo,hilarious6,FALSE,38

--- a/models/tracks/tracks.csv
+++ b/models/tracks/tracks.csv
@@ -1,62 +1,81 @@
-name,short_name,difficulty,length,folder_name,stock
-Airport 1,AP1,2,612,fdt16airport1,FALSE
-Botanical Garden,BG,0,323,garden1,TRUE
-Botanical Garden EX,BGX,2,807,fdt9xgarden,FALSE
-Calaboq,CBQ,-1,512,calaboq,FALSE
-Cardboard Castle,CC,0,426,pmt_box,FALSE
-Casino RV,CAS,1,635,casinorv,FALSE
-Castle 1,CT1,3,795,fdt21castle1,FALSE
-Castle 2,CT2,3,715,fdt22castle2,FALSE
-Desolate District 1,DD1,2,657,district,FALSE
-Downtown 1,DT1,1,800,dtown1,FALSE
-Downtown 2,DT2,3,916,dtown2,FALSE
-Fairground 1,FG1,1,363,fair1,FALSE
-Fairground 2,FG2,3,766,fair2,FALSE
-Game Room 1,GR1,1,417,fdt23arcade1,FALSE
-Game Room 2,GR2,2,635,fdt24arcade2,FALSE
-Ghost Town 1,GT1,1,324,wild_west1,TRUE
-Ghost Town 2,GT2,3,490,wild_west2,TRUE
-Grisville,GV,3,648,ghetto,FALSE
-Helios/Lunar,HL,-1,655,helios-lunar,FALSE
-Home 1,HO1,0,237,home1,FALSE
-Home 2,HO2,2,489,home2,FALSE
-Hospital 1,HP1,2,623,hospital1,FALSE
-Hospital 2,HP2,2,399,hospital2,FALSE
-Jailhouse Rock,JR,-1,729,jailhouse,FALSE
-Junkyard 2,JY2,1,517,fdt20junk2,FALSE
-Market Mayhem,MM,1,448,marketmayhem,FALSE
-Medieval: Redux,MR,0,356,medieval-redux,FALSE
-Metro-Volt,MV,-1,649,metrovolt,FALSE
-Moon Dawn,MD,3,1418,dome3,FALSE
-Museum 1,M1,2,668,muse1,TRUE
-Museum 2,M2,0,600,muse2,TRUE
-Museum 3,M3,0,539,muse3,FALSE
-Mysterious Toy-Volt Factory 1,MY1,1,504,fdt8mtvf,FALSE
-Mysterious Toy-Volt Factory 2,MY2,2,892,fdt12mtvf2,FALSE
-PetroVolt,PV,3,948,petrol,FALSE
-Port Limano 2,PL2,2,616,portlimano2,FALSE
-Port Limano EX,PLX,3,819,portlimanoex,FALSE
-Quake!,Q!,3,843,quake,FALSE
-Rooftop Chase: Redux,RCR,-1,605,roofchaseredux,FALSE
-Rooftops,RT,1,588,roof,TRUE
-Rooftops 1,RT1,3,717,roof1,False
-Sakura,SKR,-1,752,sakura,False
-Santorini,SAN,0,500,santorini,False
-School's Out! 1,SO1,1,495,schoolslite,False
-School's Out! 2,SO2,3,1545,schools,False
-Skating Toys Redux,STR,3,1011,skatoysred,False
-Spa-Volt 1,SV1,3,595,spavolt1,False
-Spa-Volt 2,SV2,3,532,spavolt2,False
-StadVolt,STV,2,571,stadvolt,False
-Subway 2,SW2,1,937,subway2,False
-SuperMarket 1,SM1,3,502,market1,TRUE
-SuperMarket 2,SM2,0,301,market2,TRUE
-Toy World 1,TW1,1,354,toylite,TRUE
-Toy World 2,TW2,1,444,toy2,TRUE
-Toy World Mayhem,TWM,-1,465,toymayhem,FALSE
-Toys in the Hood 1,TH1,0,747,nhood1,TRUE
-Toys in the Hood 2,TH2,2,592,nhood2,TRUE
-Toytanic 1,T1,2,742,ship1,TRUE
-Toytanic 2,T2,3,742,ship2,TRUE
-User-Deli: XL,DEL,3,390,user-delixl,FALSE
-Venice,VN,3,617,venice,FALSE
+name,short_name,difficulty,length,folder_name,main_author,stock
+Airport 1,AP1,2,612,fdt16airport1,Xarc,FALSE
+Aqueduct,AQU,2,426,aqueduct,hilarious6,FALSE
+Botanical Garden,BG,0,323,garden1,Acclaim Studios London,TRUE
+Botanical Garden EX,BGX,2,807,fdt9xgarden,Xarc,FALSE
+Calaboq,CBQ,-1,512,calaboq,Gforce,FALSE
+Cardboard Castle,CC,0,426,pmt_box,Paperman,FALSE
+Casino RV,CAS,1,635,casinorv,CapitaineSZM,FALSE
+Castle 1,CT1,3,795,fdt21castle1,Xarc,FALSE
+Castle 2,CT2,3,715,fdt22castle2,Xarc,FALSE
+Desolate District 1,DD1,2,657,district,RV_Pure,FALSE
+Downtown 1,DT1,1,800,dtown1,G_J,FALSE
+Downtown 2,DT2,3,916,dtown2,G_J,FALSE
+Elementary 1,E1,0,374,elementary1,G_J,FALSE
+Elementary 2,E2,0,402,elementary2,G_J,FALSE
+Fairground 1,FG1,1,363,fair1,G_J,FALSE
+Fairground 2,FG2,3,766,fair2,G_J,FALSE
+Forest Mansion 2,FM2,1,478,ccastle2,Chris Johannsen,FALSE
+Game Room 1,GR1,1,417,fdt23arcade1,Xarc,FALSE
+Game Room 2,GR2,2,635,fdt24arcade2,Xarc,FALSE
+Ghost Town 1,GT1,1,324,wild_west1,Acclaim Studios London,TRUE
+Ghost Town 2,GT2,3,490,wild_west2,Acclaim Studios London,TRUE
+Grisville,GV,3,648,ghetto,Allan1,FALSE
+Helios/Lunar,HL,-1,655,helios-lunar,Human,FALSE
+HMS Invincible,HMS,1,621,hms_redux,MOH,FALSE
+Holiday Camp,HC,-1,1170,hcampal,Marv,FALSE
+Home 1,HO1,0,237,home1,G_J,FALSE
+Home 2,HO2,2,489,home2,G_J,FALSE
+Hospital 1,HP1,2,623,hospital1,G_J,FALSE
+Hospital 2,HP2,2,399,hospital2,G_J,FALSE
+Jailhouse Rock,JR,-1,729,jailhouse,Human,FALSE
+Kadish Sprint,KS,2,814,kadishs,Dyspro50,FALSE
+Library,LIB,3,570,library,CapitaineSZM,FALSE
+Market Mayhem,MM,1,448,marketmayhem,BloodBTF,FALSE
+Metro-Volt,MV,-1,649,metrovolt,Human,FALSE
+MineZcraft,MZC,-1,438,minezcraft,Zach,FALSE
+Moon Dawn,MD,3,1418,dome3,Allan1,FALSE
+Motel in the Hood,MIH,-1,325,MotelinHood,MirkoGT97,FALSE
+Museum 1,M1,2,668,muse1,Acclaim Studios London,TRUE
+Museum 2,M2,0,600,muse2,Acclaim Studios London,TRUE
+Museum 3,M3,0,539,muse3,hilaire9,FALSE
+Museum EX,MX,3,970,fdt13xmuse,Xarc,FALSE
+Museum Unleashed,MU,2,1295,museun,maxi,FALSE
+Paper Town 1,PT1,1,350,papertown1,CapitaineSZM,FALSE
+PetroVolt,PV,3,948,petrol,Gabor,FALSE
+Port Limano 1,PL1,1,308,portlimano1,benderfan3124,FALSE
+Port Limano 2,PL2,2,616,portlimano2,benderfan3124,FALSE
+Port Limano EX,PLX,3,819,portlimanoex,benderfan3125,FALSE
+Quake!,Q!,3,843,quake,Gabor,FALSE
+Ranch,RAN,2,950,ranch,Marv,FALSE
+Rigs Highway,RH,2,671,pmt_highway,Paperman,FALSE
+Rooftop Chase: Redux,RCR,-1,605,roofchaseredux,r6te,FALSE
+Rooftops,RT,1,588,roof,Acclaim Studios London,TRUE
+Rooftops 1,RT1,3,717,roof1,G_J,FALSE
+RV Temple,RVT,-1,1116,RVT,Antimorph,FALSE
+Sakura,SKR,-1,752,sakura,Human,FALSE
+Santorini,SAN,0,500,santorini,Alexander,FALSE
+School's Out! 1,SO1,1,495,schoolslite,kiwi,FALSE
+School's Out! 2,SO2,3,1545,schools,kiwi,FALSE
+Skating Toys Redux,STR,3,1011,skatoysred,Zorbah,FALSE
+Spa-Volt 1,SV1,3,595,spavolt1,kiwi,FALSE
+Spa-Volt 2,SV2,3,532,spavolt2,kiwi,FALSE
+Spring Visit,SV,0,560,pmt_springvst,Paperman,FALSE
+StadVolt,STV,2,571,stadvolt,L17,FALSE
+Subway 2,SW2,1,937,subway2,CapitaineSZM,FALSE
+SuperMarket 1,SM1,3,502,market1,Acclaim Studios London,TRUE
+SuperMarket 2,SM2,0,301,market2,Acclaim Studios London,TRUE
+The Great Silence,TGS,3,583,winterwest,kiwi,FALSE
+Toy World 1,TW1,1,354,toylite,Acclaim Studios London,TRUE
+Toy World 2,TW2,1,444,toy2,Acclaim Studios London,TRUE
+Toy World Mayhem,TWM,-1,465,toymayhem,Killer Wheels,FALSE
+Toys in the Hood 1,TH1,0,747,nhood1,Acclaim Studios London,TRUE
+Toys in the Hood 2,TH2,2,592,nhood2,Acclaim Studios London,TRUE
+Toys in the Hood 4,TH4,3,706,nhood4,Chris Johannsen,FALSE
+Toysoldierz,TSZ,-1,454,toysoldierz,Skitch2,FALSE
+Toytanic 1,T1,2,742,ship1,Acclaim Studios London,TRUE
+Toytanic 2,T2,3,742,ship2,Acclaim Studios London,TRUE
+User-Deli: XL,DEL,3,390,user-delixl,BGM,FALSE
+Venice,VN,3,617,venice,Gabor,FALSE
+White Rose Chapel,WRC,-1,653,whiterose,hilaire9,FALSE
+Wladyslawowo,WLW,2,619,wladyslawowo,hilarious6,FALSE

--- a/models/tracks/tracks.csv
+++ b/models/tracks/tracks.csv
@@ -1,81 +1,82 @@
-name,short_name,difficulty,length,folder_name,main_author,stock
-Airport 1,AP1,2,612,fdt16airport1,Xarc,FALSE
-Aqueduct,AQU,2,426,aqueduct,hilarious6,FALSE
-Botanical Garden,BG,0,323,garden1,Acclaim Studios London,TRUE
-Botanical Garden EX,BGX,2,807,fdt9xgarden,Xarc,FALSE
-Calaboq,CBQ,-1,512,calaboq,Gforce,FALSE
-Cardboard Castle,CC,0,426,pmt_box,Paperman,FALSE
-Casino RV,CAS,1,635,casinorv,CapitaineSZM,FALSE
-Castle 1,CT1,3,795,fdt21castle1,Xarc,FALSE
-Castle 2,CT2,3,715,fdt22castle2,Xarc,FALSE
-Desolate District 1,DD1,2,657,district,RV_Pure,FALSE
-Downtown 1,DT1,1,800,dtown1,G_J,FALSE
-Downtown 2,DT2,3,916,dtown2,G_J,FALSE
-Elementary 1,E1,0,374,elementary1,G_J,FALSE
-Elementary 2,E2,0,402,elementary2,G_J,FALSE
-Fairground 1,FG1,1,363,fair1,G_J,FALSE
-Fairground 2,FG2,3,766,fair2,G_J,FALSE
-Forest Mansion 2,FM2,1,478,ccastle2,Chris Johannsen,FALSE
-Game Room 1,GR1,1,417,fdt23arcade1,Xarc,FALSE
-Game Room 2,GR2,2,635,fdt24arcade2,Xarc,FALSE
-Ghost Town 1,GT1,1,324,wild_west1,Acclaim Studios London,TRUE
-Ghost Town 2,GT2,3,490,wild_west2,Acclaim Studios London,TRUE
-Grisville,GV,3,648,ghetto,Allan1,FALSE
-Helios/Lunar,HL,-1,655,helios-lunar,Human,FALSE
-HMS Invincible,HMS,1,621,hms_redux,MOH,FALSE
-Holiday Camp,HC,-1,1170,hcampal,Marv,FALSE
-Home 1,HO1,0,237,home1,G_J,FALSE
-Home 2,HO2,2,489,home2,G_J,FALSE
-Hospital 1,HP1,2,623,hospital1,G_J,FALSE
-Hospital 2,HP2,2,399,hospital2,G_J,FALSE
-Jailhouse Rock,JR,-1,729,jailhouse,Human,FALSE
-Kadish Sprint,KS,2,814,kadishs,Dyspro50,FALSE
-Library,LIB,3,570,library,CapitaineSZM,FALSE
-Market Mayhem,MM,1,448,marketmayhem,BloodBTF,FALSE
-Metro-Volt,MV,-1,649,metrovolt,Human,FALSE
-MineZcraft,MZC,-1,438,minezcraft,Zach,FALSE
-Moon Dawn,MD,3,1418,dome3,Allan1,FALSE
-Motel in the Hood,MIH,-1,325,MotelinHood,MirkoGT97,FALSE
-Museum 1,M1,2,668,muse1,Acclaim Studios London,TRUE
-Museum 2,M2,0,600,muse2,Acclaim Studios London,TRUE
-Museum 3,M3,0,539,muse3,hilaire9,FALSE
-Museum EX,MX,3,970,fdt13xmuse,Xarc,FALSE
-Museum Unleashed,MU,2,1295,museun,maxi,FALSE
-Paper Town 1,PT1,1,350,papertown1,CapitaineSZM,FALSE
-PetroVolt,PV,3,948,petrol,Gabor,FALSE
-Port Limano 1,PL1,1,308,portlimano1,benderfan3124,FALSE
-Port Limano 2,PL2,2,616,portlimano2,benderfan3124,FALSE
-Port Limano EX,PLX,3,819,portlimanoex,benderfan3125,FALSE
-Quake!,Q!,3,843,quake,Gabor,FALSE
-Ranch,RAN,2,950,ranch,Marv,FALSE
-Rigs Highway,RH,2,671,pmt_highway,Paperman,FALSE
-Rooftop Chase: Redux,RCR,-1,605,roofchaseredux,r6te,FALSE
-Rooftops,RT,1,588,roof,Acclaim Studios London,TRUE
-Rooftops 1,RT1,3,717,roof1,G_J,FALSE
-RV Temple,RVT,-1,1116,RVT,Antimorph,FALSE
-Sakura,SKR,-1,752,sakura,Human,FALSE
-Santorini,SAN,0,500,santorini,Alexander,FALSE
-School's Out! 1,SO1,1,495,schoolslite,kiwi,FALSE
-School's Out! 2,SO2,3,1545,schools,kiwi,FALSE
-Skating Toys Redux,STR,3,1011,skatoysred,Zorbah,FALSE
-Spa-Volt 1,SV1,3,595,spavolt1,kiwi,FALSE
-Spa-Volt 2,SV2,3,532,spavolt2,kiwi,FALSE
-Spring Visit,SV,0,560,pmt_springvst,Paperman,FALSE
-StadVolt,STV,2,571,stadvolt,L17,FALSE
-Subway 2,SW2,1,937,subway2,CapitaineSZM,FALSE
-SuperMarket 1,SM1,3,502,market1,Acclaim Studios London,TRUE
-SuperMarket 2,SM2,0,301,market2,Acclaim Studios London,TRUE
-The Great Silence,TGS,3,583,winterwest,kiwi,FALSE
-Toy World 1,TW1,1,354,toylite,Acclaim Studios London,TRUE
-Toy World 2,TW2,1,444,toy2,Acclaim Studios London,TRUE
-Toy World Mayhem,TWM,-1,465,toymayhem,Killer Wheels,FALSE
-Toys in the Hood 1,TH1,0,747,nhood1,Acclaim Studios London,TRUE
-Toys in the Hood 2,TH2,2,592,nhood2,Acclaim Studios London,TRUE
-Toys in the Hood 4,TH4,3,706,nhood4,Chris Johannsen,FALSE
-Toysoldierz,TSZ,-1,454,toysoldierz,Skitch2,FALSE
-Toytanic 1,T1,2,742,ship1,Acclaim Studios London,TRUE
-Toytanic 2,T2,3,742,ship2,Acclaim Studios London,TRUE
-User-Deli: XL,DEL,3,390,user-delixl,BGM,FALSE
-Venice,VN,3,617,venice,Gabor,FALSE
-White Rose Chapel,WRC,-1,653,whiterose,hilaire9,FALSE
-Wladyslawowo,WLW,2,619,wladyslawowo,hilarious6,FALSE
+name;short_name;difficulty;length;folder_name;main_author;stock;average_lap_time
+Airport 1;AP1;2;612;fdt16airport1;Xarc;FALSE;35
+Aqueduct;AQU;2;426;aqueduct;hilarious6;FALSE;31
+Botanical Garden;BG;0;323;garden1;Acclaim Studios London;TRUE;22
+Botanical Garden EX;BGX;2;807;fdt9xgarden;Xarc;FALSE;45
+Calaboq;CBQ;-1;512;calaboq;Gforce;FALSE;33
+Cardboard Castle;CC;0;426;pmt_box;Paperman;FALSE;26
+Casino RV;CAS;1;635;casinorv;CapitaineSZM;FALSE;42
+Castle 1;CT1;3;795;fdt21castle1;Xarc;FALSE;42
+Castle 2;CT2;3;715;fdt22castle2;Xarc;FALSE;41
+Desolate District 1;DD1;2;657;district;RV_Pure;FALSE;42
+Downtown 1;DT1;1;800;dtown1;G_J;FALSE;46
+Downtown 2;DT2;3;916;dtown2;G_J;FALSE;50
+Elementary 1;E1;0;374;elementary1;G_J;FALSE;27
+Elementary 2;E2;0;402;elementary2;G_J;FALSE;27
+Fairground 1;FG1;1;363;fair1;G_J;FALSE;24
+Fairground 2;FG2;3;766;fair2;G_J;FALSE;45
+Forest Mansion 2;FM2;1;478;ccastle2;Chris Johannsen;FALSE;33
+Game Room 1;GR1;1;417;fdt23arcade1;Xarc;FALSE;26
+Game Room 2;GR2;2;635;fdt24arcade2;Xarc;FALSE;37
+Ghost Town 1;GT1;1;324;wild_west1;Acclaim Studios London;TRUE;22
+Ghost Town 2;GT2;3;490;wild_west2;Acclaim Studios London;TRUE;30
+Grisville;GV;3;648;ghetto;Allan1;FALSE;44
+Helios/Lunar;HL;-1;655;helios-lunar;Human;FALSE;42
+HMS Invincible;HMS;1;621;hms_redux;MOH;FALSE;38
+Holiday Camp;HC;-1;1170;hcampal;Marv;FALSE;76
+Home 1;HO1;0;237;home1;G_J;FALSE;13.8
+Home 2;HO2;2;489;home2;G_J;FALSE;27
+Hospital 1;HP1;2;623;hospital1;G_J;FALSE;35
+Hospital 2;HP2;2;399;hospital2;G_J;FALSE;26
+Jailhouse Rock;JR;-1;729;jailhouse;Human;FALSE;45
+Kadish Sprint;KS;2;814;kadishs;Dyspro50;FALSE;56
+Library;LIB;3;570;library;CapitaineSZM;FALSE;45
+Market Mayhem;MM;1;448;marketmayhem;BloodBTF;FALSE;26
+Metro-Volt;MV;-1;649;metrovolt;Human;FALSE;42
+MineZcraft;MZC;-1;438;minezcraft;Zach;FALSE;32
+Moon Dawn;MD;3;1418;dome3;Allan1;FALSE;92
+Motel in the Hood;MIH;-1;325;motelinhood;MirkoGT97;FALSE;31
+Museum 1;M1;2;668;muse1;Acclaim Studios London;TRUE;46
+Museum 2;M2;0;600;muse2;Acclaim Studios London;TRUE;34
+Museum 3;M3;0;539;muse3;hilaire9;FALSE;40
+Museum EX;MX;3;970;fdt13xmuse;Xarc;FALSE;54
+Museum Unleashed;MU;2;1295;museun_rva;maxi;FALSE;75
+Paper Town 1;PT1;1;350;papertown1;CapitaineSZM;FALSE;22
+PetroVolt;PV;3;948;petrol;Gabor;FALSE;50
+Port Limano 1;PL1;1;308;portlimano1;benderfan3124;FALSE;22
+Port Limano 2;PL2;2;616;portlimano2;benderfan3124;FALSE;38
+Port Limano EX;PLX;3;819;portlimanoex;benderfan3124;FALSE;43
+Quake!;Q!;3;843;quake;Gabor;FALSE;49
+Ranch;RAN;2;950;ranch;Marv;FALSE;72
+Rigs Highway;RH;2;671;pmt_highway;Paperman;FALSE;42
+Rooftop Chase: Redux;RCR;-1;605;roofchaseredux;r6te;FALSE;46
+Rooftops;RT;1;588;roof;Acclaim Studios London;TRUE;38
+Rooftops 1;RT1;3;717;roof1;G_J;FALSE;50
+RV Temple;RVT;-1;1116;rvt_rva;Antimorph;FALSE;75
+Sakura;SKR;-1;752;sakura;Human;FALSE;45
+Santorini;SAN;0;500;santorini;Alexander;FALSE;28
+School's Out! 1;SO1;1;495;schoolslite;kiwi;FALSE;30
+School's Out! 2;SO2;3;1545;schools;kiwi;FALSE;106
+Skating Toys Redux;STR;3;1011;skatoysred;Zorbah;FALSE;71
+Spa-Volt 1;SV1;3;595;spavolt1;kiwi;FALSE;44
+Spa-Volt 2;SV2;3;532;spavolt2;kiwi;FALSE;35
+Spring Visit;SV;0;560;pmt_springvst;Paperman;FALSE;35
+StadVolt;STV;2;571;stadvolt;L17;FALSE;32
+Subway 2;SW2;1;937;subway2;CapitaineSZM;FALSE;65
+SuperMarket 1;SM1;3;502;market1;Acclaim Studios London;TRUE;32
+SuperMarket 2;SM2;0;301;market2;Acclaim Studios London;TRUE;17
+The Great Silence;TGS;3;583;winterwest;kiwi;FALSE;42
+Toy World 1;TW1;1;354;toylite;Acclaim Studios London;TRUE;22
+Toy World 2;TW2;1;444;toy2;Acclaim Studios London;TRUE;28
+Toy World Mayhem;TWM;-1;465;toymayhem;Killer Wheels;FALSE;33
+Toys in the Hood 1;TH1;0;747;nhood1;Acclaim Studios London;TRUE;40
+Toys in the Hood 2;TH2;2;592;nhood2;Acclaim Studios London;TRUE;35
+Toys in the Hood 4;TH4;3;706;nhood4;Chris Johannsen;FALSE;40
+ToySoldierz;TSZ;-1;454;toysoldierz;Skitch2;FALSE;34
+Toytanic 1;T1;2;742;ship1;Acclaim Studios London;TRUE;42
+Toytanic 2;T2;3;742;ship2;Acclaim Studios London;TRUE;42
+User-Deli: XL;DEL;3;390;user-delixl;BGM;FALSE;39
+Venice;VN;3;617;venice;Gabor;FALSE;40
+White Rose Chapel;WRC;-1;653;whiterose;hilaire9;FALSE;45
+Wladyslawowo;WLW;2;619;wladyslawowo;hilarious6;FALSE;38
+;;;;;;;


### PR DESCRIPTION
- 24 new tracks added: Aqueduct, Elementary 1, Elementary 2, Forest Mansion 2, HMS Invincible, Holiday Camp: California Edition, Hull Breach 3000 (RVA), Kadish Sprint, Library, MineZcraft, Motel in the Hood, Museum EX, Museum Unleashed (RVA), Paper Town 1, Port Limano 1, Ranch, Rigs Highway, RV Temple (RVA), Spring Visit, The Great Silence, Toys in the Hood 4, ToySoldierz, White Rose Chapel, Wladyslawowo.
- "Author" column added.

Note: Władysławowo should have this special 'ł' character but the web font used doesn't have it, so I'm writing it with a regular L.