### PR TITLE
Updated Cars models to Season 2024-A

### DIFF
--- a/models/cars/advanced.csv
+++ b/models/cars/advanced.csv
@@ -1,36 +1,33 @@
-name,speed,acc,weight,multiplier,folder_name,stock
-R6 Turbo,59.4,2.47,0.8,0.7,r5,TRUE
-Alice,54.7,2.31,1.4,0.7,alice,FALSE
-Glass Cannon,52.5,13.7,0.7,0.7,tcp_glass,FALSE
-Kyoki,56.8,2.73,1.4,0.7,kyoki,FALSE
-Neifion,56.5,2.39,1.7,0.7,fd154neifion,FALSE
-Top Tier,55,2.28,1.4,0.7,fd89top,FALSE
-Bertha Ballistics,56.9,2.24,3,0.8,sgt,TRUE
-Arctic Stomper,57,2.38,2.3,0.8,gtc_arcstomper,FALSE
-Camelia,58.8,2.78,1.71,0.8,camelia,FALSE
-Drawall,54.2,2.67,1.4,0.8,lib7a_spray,FALSE
-Le Pastel,56.8,2.14,2,0.8,fd110pastel,FALSE
-Nano Rascal,50,2.25,0.99,0.8,nanorascal,FALSE
-Rice Ball,59.4,2.05,1.6,0.8,rice,FALSE
-Springtrap,55,2.8,1.2,0.8,rv2_buggy,FALSE
-XTAR,61.3,2.41,2,0.8,nrf_xtar,FALSE
-Dust Shot,54.8,2.19,1.5,0.9,dustshot,FALSE
-DRJ-61,54.7,2.44,2,0.9,phim_drj-61,FALSE
-Emperor,57.6,2.34,2,0.9,emperor,FALSE
-Hyper XL,57.6,2.7,1.75,0.9,fd54hyper,FALSE
-Llag Sat,58.6,2.14,3.2,0.9,nrf_lag,FALSE
-WILL,57,2.47,1.65,0.9,phim_will,FALSE
-YNZ,58.7,2.16,1.7,0.9,nrf_ynz,FALSE
-Panga TC,59.9,2.13,1.8,1.0,tc2,TRUE
-Shocker,57.2,2.13,1.8,1.0,tc8,TRUE
-Diamond,55.9,2.23,1.2,1.0,diamond,FALSE
-Metal Masher,53.4,2.59,2.7,1.0,jgp_metalmasher,FALSE
-Donnie TC,58,2.73,1.7,1.1,donnietc,FALSE
-Flower Power,57.8,2.76,1.6,1.1,flowerpower2,FALSE
-Panther,62.9,2.18,1.65,1.1,panthergto,FALSE
-BossVolt,57.4,2.16,3.5,1.2,bossvolt,TRUE
-Groovster,55.7,1.66,2,1.2,tc9,TRUE
-Evil Weasel,58.4,1.95,1.4,1.3,flag,TRUE
-NY 54,57.6,1.62,1.6,1.4,tc5,TRUE
-Akagi Attacker,55.5,4.29,1.5,1.5,fd_s19,FALSE
-Splat,54.1,1.62,1.6,1.9,tc11,TRUE
+name,speed,acc,weight,multiplier,folder_name,author,stock
+R6 Turbo,59.4,2.47,0.8,0.7,r5,Acclaim Studios London,TRUE
+Alpina XL,54.6,2.63,1.8,0.7,tcp_alpina,Trixed,FALSE
+Glass Cannon,52.5,13.7,0.7,0.7,tcp_glass,Norfair,FALSE
+Kyoki,56.8,2.73,1.4,0.7,kyoki,Trixed,FALSE
+Top Tier,55,2.28,1.4,0.7,fd89top,Xarc,FALSE
+Bertha Ballistics,56.9,2.24,3,0.8,sgt,Acclaim Studios London,TRUE
+Arctic Stomper,57,2.38,2.3,0.8,gtc_arcstomper,Ghosterino,FALSE
+Drawall,54.2,2.67,1.4,0.8,lib7a_spray,Paperman,FALSE
+Exert,60.4,2.37,1.25,0.8,exert,burner94,FALSE
+Le Pastel,56.8,2.14,2,0.8,fd110pastel,Xarc,FALSE
+Springtrap,55,2.8,1.2,0.8,rv2_buggy,MightyCucumber,FALSE
+Breaker,57.5,2.06,1.6,0.9,breaker,TTDriver,FALSE
+Dust Shot,54.8,2.19,1.5,0.9,dustshot,TTDriver,FALSE
+DRJ-61,54.7,2.44,2,0.9,phim_drj-61,Phimeek,FALSE
+Emperor,57.6,2.34,2,0.9,emperor,Trixed,FALSE
+Llag Sat,58.6,2.14,3.2,0.9,nrf_lag,Norfair,FALSE
+Looper,54.8,3.27,1.6,0.9,tcp_looper,Norfair,FALSE
+WILL,57,2.47,1.65,0.9,phim_will,Phimeek,FALSE
+YNZ,58.7,2.16,1.7,0.9,nrf_ynz,Norfair,FALSE
+Panga TC,59.9,2.13,1.8,1.0,tc2,Acclaim Studios London,TRUE
+Shocker,57.2,2.13,1.8,1.0,tc8,Acclaim Studios London,TRUE
+Diamond,55.9,2.23,1.2,1.0,diamond,TTDriver,FALSE
+Metal Masher,53.4,2.59,2.7,1.0,jgp_metalmasher,Ghosterino,FALSE
+Flower Power,57.8,2.76,1.6,1.1,flowerpower2,MightyCucumber,FALSE
+Moonshine XL,58.1,2.75,1.8,1.1,tcp_moonshine,Norfair,FALSE
+Panther,62.9,2.18,1.65,1.1,panthergto,kiwi,FALSE
+BossVolt,57.4,2.16,3.5,1.2,bossvolt,Acclaim Studios London,TRUE
+Groovster,55.7,1.66,2,1.2,tc9,Acclaim Studios London,TRUE
+Evil Weasel,58.4,1.95,1.4,1.3,flag,Acclaim Studios London,TRUE
+NY 54,57.6,1.62,1.6,1.4,tc5,Acclaim Studios London,TRUE
+Akagi Attacker,55.5,4.29,1.5,1.5,fd_s19,Xarc,FALSE
+Splat,54.1,1.62,1.6,1.9,tc11,Acclaim Studios London,TRUE

--- a/models/cars/amateur.csv
+++ b/models/cars/amateur.csv
@@ -1,36 +1,33 @@
-name,speed,acc,weight,multiplier,folder_name,stock
-RC San,53.3,3.17,1,0.7,dino,TRUE
-Aquasonic,55.1,2.42,1.4,0.7,tc4,TRUE
-Honeybee,54.4,2.31,1.5,0.7,honey,FALSE
-Outraga,53.8,2.42,1.35,0.7,fd46rage,FALSE
-Rad Signal,52.4,2.64,1.2,0.7,tcp_doh,FALSE
-RC Halo,52.9,2.19,1.9,0.7,tcp_homage,FALSE
-Smokie,58.2,2.41,1.6,0.7,smokie,FALSE
-Vixen,51.8,2.47,1.5,0.7,tx9vix,FALSE
-LA 54,52,2.52,1.2,0.8,tc12,TRUE
-Matra XL,55.8,2.12,1.4,0.8,tc10,TRUE
-AMCO TC,51.2,2.3,3.7,0.8,amcotc,FALSE
-Ashley,53.5,3.1,1.4,0.8,fd118ash,FALSE
-Bumblebee,50.4,2.28,1.1,0.8,bumblebee,FALSE
-Ignit-9,51.9,2.3,1.5,0.8,lib9a_ignit,FALSE
-LMW,56.1,1.74,2,0.8,nrf_lmw,FALSE
-Locker,52.1,2.98,1.4,0.8,tclock,FALSE
-Sugar N' Spice,53.5,1.92,2.2,0.8,tcp_sugar,FALSE
-Candy Pebbles,55.3,1.83,1.3,0.9,candy,TRUE
-Baja Dash,49.9,2.52,2,0.9,lib8a_dash,FALSE
-Mongoose,53.1,2,1.4,0.9,mongoose,FALSE
-Muller GT,52.4,2.41,1.4,0.9,muller_gt,FALSE
-Stonemason,55,2,2.3,0.9,rip,FALSE
-Strax,50.4,2.58,1.4,0.9,strax,FALSE
-The Rook,55.3,1.93,1.3,0.9,tcp_rook,FALSE
-X-6 Nitro,51.8,2.3,1.6,0.9,jgp_x6,FALSE
-Mouse,54.7,2.9,2.3,1.0,mouse,TRUE
-Kyarus,52.2,3.15,1.3,1.0,kyarus,FALSE
-Phantum,55.2,1.88,1.6,1.0,phantum,FALSE
-Reddlum,53.4,2.9,1.8,1.0,reddlum,FALSE
-Road King,50.1,3.13,2.8,1.0,roadking,FALSE
-Slim,52.3,2.27,1.3,1.0,lib16c_slim,FALSE
-Queen Bee,52.3,2.33,1.9,1.2,tcp_drifter,FALSE
-Six Shooter,52.1,2.92,1.94,1.2,sixshooter,FALSE
-RC Phink,49.8,2.28,1.6,1.4,jg6rc,TRUE
-Genghis Kar,56.5,1.66,2,1.6,gencar,TRUE
+name,speed,acc,weight,multiplier,folder_name,author,stock
+RC San,53.3,3.17,1,0.7,dino,Acclaim Studios London,TRUE
+Aquasonic,55.1,2.42,1.4,0.7,tc4,Acclaim Studios London,TRUE
+Moffat Snake,50.4,2.31,1.3,0.7,moffat,Trixed,FALSE
+Outraga,53.8,2.42,1.35,0.7,fd46rage,Xarc,FALSE
+Rad Signal,52.4,2.64,1.2,0.7,tcp_doh,Norfair,FALSE
+RC Halo,52.9,2.19,1.9,0.7,tcp_homage,Trixed,FALSE
+Smokie,58.2,2.41,1.6,0.7,smokie,kiwi,FALSE
+LA 54,52,2.52,1.2,0.8,tc12,Acclaim Studios London,TRUE
+Matra XL,55.8,2.12,1.4,0.8,tc10,Acclaim Studios London,TRUE
+AMCO TC,51.2,2.3,3.7,0.8,amcotc,Zeino,FALSE
+Bumblebee,50.4,2.28,1.1,0.8,bumblebee,kiwi,FALSE
+Ignit-9,51.9,2.3,1.5,0.8,lib9a_ignit,Paperman,FALSE
+LMW,56.1,1.74,2,0.8,nrf_lmw,Norfair,FALSE
+Lineage,52.3,1.95,2.5,0.8,lineage,BrotatoTheBadassSpud,FALSE
+Locker,52.1,2.98,1.4,0.8,tclock,BloodBTF,FALSE
+Candy Pebbles,55.3,1.83,1.3,0.9,candy,Acclaim Studios London,TRUE
+Baja Dash,49.9,2.52,2,0.9,lib8a_dash,Norfair,FALSE
+Fun Zone,53.7,2.28,1.3,0.9,tcp_party,MightyCucumber,FALSE
+Mongoose,53.1,2,1.4,0.9,mongoose,Norfair,FALSE
+Strax,50.4,2.58,1.4,0.9,strax,kiwi,FALSE
+The Rook,55.3,1.93,1.3,0.9,tcp_rook,Trixed,FALSE
+Tin Lizzie,55,2.71,0.7,0.9,tinlizzie,Zeino,FALSE
+X-6 Nitro,51.8,2.3,1.6,0.9,jgp_x6,Ghosterino,FALSE
+Mouse,54.7,2.9,2.3,1.0,mouse,Acclaim Studios London,TRUE
+Kyarus,52.2,3.15,1.3,1.0,kyarus,MightyCucumber,FALSE
+Reddlum,53.4,2.9,1.8,1.0,reddlum,MightyCucumber,FALSE
+Road King,50.1,3.13,2.8,1.0,roadking,Xarc,FALSE
+Slim,52.3,2.27,1.3,1.0,lib16c_slim,Xarc,FALSE
+Queen Bee,52.3,2.33,1.9,1.2,tcp_drifter,Trixed,FALSE
+Downforce,56.1,4.18,0.75,1.3,downforce,Zeino,FALSE
+RC Phink,49.8,2.28,1.6,1.4,jg6rc,Acclaim Studios London,TRUE
+Genghis Kar,56.5,1.66,2,1.6,gencar,Acclaim Studios London,TRUE

--- a/models/cars/pro.csv
+++ b/models/cars/pro.csv
@@ -1,36 +1,33 @@
-name,speed,acc,weight,multiplier,folder_name,stock
-Toyeca,64.8,3.2,2,0.7,toyeca,TRUE
-Purp XL,67.4,3.20,2,0.7,jg5purpxl,TRUE
-SNW 35,65.8,4.32,1.5,0.7,jg4snw35,TRUE
-Abomin8r,65.7,3.13,2.5,0.7,abomina10,FALSE
-Drome Champ,63.2,3.31,1.5,0.7,dromechamp,FALSE
-Outlaw,66.2,2.62,2,0.7,nrf_outlaw,FALSE
-Ridgeback,65.6,3.3,1.9,0.7,ridgeback,FALSE
-Ryu,64.1,3.33,1.5,0.7,ryu,FALSE
-Sin,63.2,4.75,1.8,0.7,nrf_sin,FALSE
-Burning Steel,68.1,3.5,1.45,0.8,brnsteel,FALSE
-Chimera TC,61.4,3.73,1.6,0.8,chimtc,FALSE
-Dasher TC,65,4.01,1.5,0.8,tcp_rally,FALSE
-Puma,64.5,4.14,1.8,0.8,nrf_puma,FALSE
-Wattage,65.5,3.21,1.8,0.8,tcp_watt,FALSE
-Humma,64,3.45,2,0.9,sugo,TRUE
-Steezy,66,3.07,1.7,0.9,steezy,FALSE
-Y Force,67.2,2.73,2,0.9,fd158yforce,FALSE
-Acclaim F1,66.8,3.66,1.0,1.0,acclaimf1,FALSE
-Karen,65.2,2.86,1.8,1.0,phim_jgkaren,FALSE
-Polar Star,64.5,2.11,1.5,1.0,gtc_polarstar,FALSE
-Sucker Punch,66.6,3.18,1.25,1.0,fan,FALSE
-Visconti R,63.2,3.43,1.8,1.0,visconti,FALSE
-Wildstar,66.3,3.6,1,1.0,wildstar,FALSE
-Patriot,73.7,5.04,1.9,1.1,patriot,FALSE
-Toro GT84,70.4,2.92,1.5,1.1,gt84,FALSE
-Sir Gleam,67.4,4.45,1,1.2,gleam,FALSE
-Tegelhus,71.2,2.31,2.7,1.2,tigel,FALSE
-Truckenstein,67.4,2.71,2.8,1.2,gtc_truckenstein,FALSE
-RC Bulldog,70.5,2.81,5,1.4,bulldog,FALSE
-Star Oil,64.5,2.81,2.5,1.4,fd140oil,FALSE
-Superdriver,62.9,5.45,1.4,1.4,superdriver,FALSE
-Cougar,69.7,2.36,2,1.6,cougar,TRUE
-Panga,69.6,2.73,2.5,1.8,panga,TRUE
-AMW,68.2,2.31,1,2.5,amw,TRUE
-Fulon X,62.5,2.05,1.2,3.2,jg2fulonx,TRUE
+name,speed,acc,weight,multiplier,folder_name,author,stock
+Toyeca,64.8,3.2,2,0.7,toyeca,Acclaim Studios London,TRUE
+Purp XL,67.4,3.20,2,0.7,jg5purpxl,Acclaim Studios London,TRUE
+SNW 35,65.8,4.32,1.5,0.7,jg4snw35,Acclaim Studios London,TRUE
+Outlaw,66.2,2.62,2,0.7,nrf_outlaw,Norfair,FALSE
+Ridgeback,65.6,3.3,1.9,0.7,ridgeback,Norfair,FALSE
+Ryu,64.1,3.33,1.5,0.7,ryu,Trixed,FALSE
+Spettrale,63.8,4.88,2,0.7,phim_spettrale,Phimeek,FALSE
+Chimera TC,61.4,3.73,1.6,0.8,chimtc,BloodBTF,FALSE
+Giga Chief,69.1,2.3,2.7,0.8,gtc_gigachief,Ghosterino,FALSE
+Invictus,66.1,3.25,2,0.8,victus,Trixed,FALSE
+Puma,64.5,4.14,1.8,0.8,nrf_puma,Norfair,FALSE
+Wattage,65.5,3.21,1.8,0.8,tcp_watt,Norfair,FALSE
+Humma,64,3.45,2,0.9,sugo,Acclaim Studios London,TRUE
+Broadley,69.2,2.21,1.7,0.9,gtc_broadley,Ghosterino,FALSE
+Roadzilla,65.4,4.85,1.66,0.9,tcp_rex,MightyCucumber,FALSE
+Steezy,66,3.07,1.7,0.9,steezy,Norfair,FALSE
+Y Force,67.2,2.73,2,0.9,fd158yforce,Xarc,FALSE
+Acclaim F1,66.8,3.66,1.0,1.0,acclaimf1,MightyCucumber,FALSE
+Polar Star,64.5,2.11,1.5,1.0,gtc_polarstar,Ghosterino,FALSE
+Sucker Punch,66.6,3.18,1.25,1.0,fan,burner94,FALSE
+Visconti R,63.2,3.43,1.8,1.0,visconti,burner94,FALSE
+Wildstar,66.3,3.6,1,1.0,wildstar,TTDriver,FALSE
+Patriot,73.7,5.04,1.9,1.1,patriot,MightyCucumber,FALSE
+Toro GT84,70.4,2.92,1.5,1.1,gt84,Flo,FALSE
+Ektoplazm,68.7,4.58,1.5,1.2,tcp_ekto,Trixed,FALSE
+Sir Gleam,67.4,4.45,1,1.2,gleam,MightyCucumber,FALSE
+RC Bulldog,70.5,2.81,5,1.4,bulldog,Trixed,FALSE
+Superdriver,62.9,5.45,1.4,1.4,superdriver,burner94,FALSE
+Cougar,69.7,2.36,2,1.6,cougar,Acclaim Studios London,TRUE
+Panga,69.6,2.73,2.5,1.8,panga,Acclaim Studios London,TRUE
+AMW,68.2,2.31,1,2.5,amw,Acclaim Studios London,TRUE
+Fulon X,62.5,2.05,1.2,3.2,jg2fulonx,Acclaim Studios London,TRUE

--- a/models/cars/rookie.csv
+++ b/models/cars/rookie.csv
@@ -1,36 +1,33 @@
-name,speed,acc,weight,multiplier,folder_name,stock
-RC Bandit,51.7,2.09,1.2,0.7,rc,TRUE
-Dr. Grudge,51.3,2.54,1.4,0.7,beatall,TRUE
-Sprinter XL,50.7,3.2,0.9,0.7,tc6,TRUE
-E-Razr,47.2,3.1,1.1,0.7,erazer,FALSE
-Hurricane,48.8,2.3,1.5,0.7,hurri,FALSE
-Iso-77A,48.8,3.03,1.33,0.7,iso77,FALSE
-Kanberra Kruiser,50.8,2.38,1,0.7,kkruise,FALSE
-Harvester,47.9,2.32,1.7,0.8,mud,TRUE
-Albatross GT,48.5,2.36,1.4,0.8,albatrossgt,FALSE
-Bed Bug,52.1,1.98,1.2,0.8,bedbug2,FALSE
-Condor GRV,51.5,2.73,1.5,0.8,condorgrv,FALSE
-El Gekko,51.3,2.01,1.2,0.8,gekko,FALSE
-Funk Flea,51.0,2.77,1.14,0.8,flea,FALSE
-High-Rod,49,2.17,1.9,0.8,rod,FALSE
-Hot Spot,51.3,2.36,1,0.8,hs,FALSE
-LR 64,54.1,1.55,1.7,0.8,fd64lost,FALSE
-Panorama,50.6,2.3,1.35,0.8,fd50pano,FALSE
-Road Star,50.3,2.49,0.8,0.8,roadstar,FALSE
-Col. Moss,52.8,2.17,1.5,0.9,moss,TRUE
-Volken Turbo,49.5,2.24,1.6,0.9,volken,TRUE
-BigVolt,52.8,2.36,2.3,0.9,bigvolt,TRUE
-Ferrada,54.1,2.06,1.2,0.9,ferrada,FALSE
-Nesbitt,53.5,1.81,1.5,0.9,nesbitt,FALSE
-Rebound 4X4,53.8,2.25,1.5,0.9,rebound,FALSE
-Gunior,51,2.67,1.3,1.0,fd114gunior,FALSE
-Toukka 4x4,49.1,2.47,2.2,1.0,toukka,FALSE
-Get Air,51.7,3.31,2.7,1.1,getair,FALSE
-Rouge,52,2.57,1.2,1.1,fd25sporty,FALSE
-Super Wheat,52.4,1.86,2.4,1.1,swheat,FALSE
-Dust Mite,50.5,1.98,1.2,1.2,mite,TRUE
-Piccino,50.1,3.11,0.85,1.2,midgetii,FALSE
-HSF-1,48.4,2.29,1.42,1.4,hsf1,FALSE
-Phat Slug,50.8,1.41,2.5,1.7,phat,TRUE
-Shiawase,41.6,1,5,2.0,shiawasecrimsonsolace,FALSE
-Creeki Leeki,49.9,2.16,1.2,3.0,gtcnd_creekileeki,FALSE
+name,speed,acc,weight,multiplier,folder_name,author,stock
+RC Bandit,51.7,2.09,1.2,0.7,rc,Acclaim Studios London,TRUE
+Dr. Grudge,51.3,2.54,1.4,0.7,beatall,Acclaim Studios London,TRUE
+Sprinter XL,50.7,3.2,0.9,0.7,tc6,Acclaim Studios London,TRUE
+Cheat Code Central,49.6,1.95,1.6,0.7,phim_cheatcc,Phimeek,FALSE
+E-Razr,47.2,3.1,1.1,0.7,erazer,MightyCucumber,FALSE
+Hurricane,48.8,2.3,1.5,0.7,hurri,MightyCucumber,FALSE
+Harvester,47.9,2.32,1.7,0.8,mud,Acclaim Studios London,TRUE
+Albatross GT,48.5,2.36,1.4,0.8,albatrossgt,BloodBTF,FALSE
+Condor GRV,51.5,2.73,1.5,0.8,condorgrv,TTDriver,FALSE
+Funk Flea,51.0,2.77,1.14,0.8,flea,MightyCucumber,FALSE
+High-Rod,49,2.17,1.9,0.8,rod,MightyCucumber,FALSE
+LR 64,54.1,1.55,1.7,0.8,fd64lost,Xarc,FALSE
+Mr Bedtime,54.9,1.94,1.8,0.8,mrbedtime,Zeino,FALSE
+Panorama,50.6,2.3,1.35,0.8,fd50pano,Xarc,FALSE
+Road Star,50.3,2.49,0.8,0.8,roadstar,Trixed,FALSE
+Col. Moss,52.8,2.17,1.5,0.9,moss,Acclaim Studios London,TRUE
+Volken Turbo,49.5,2.24,1.6,0.9,volken,Acclaim Studios London,TRUE
+BigVolt,52.8,2.36,2.3,0.9,bigvolt,Acclaim Studios London,TRUE
+Beeble,52.3,2.38,1.2,0.9,beeble,MightyCucumber,FALSE
+Ferrada,54.1,2.06,1.2,0.9,ferrada,TTDriver,FALSE
+Nesbitt,53.5,1.81,1.5,0.9,nesbitt,Skarma,FALSE
+Rebound 4X4,53.8,2.25,1.5,0.9,rebound,Paperman,FALSE
+Turbo Katto,46.8,2.48,4,0.9,katto,burner94,FALSE
+Toukka 4x4,49.1,2.47,2.2,1.0,toukka,Zeino,FALSE
+Get Air,51.7,3.31,2.7,1.1,getair,MightyCucumber,FALSE
+Rouge,52,2.57,1.2,1.1,fd25sporty,Xarc,FALSE
+Toon Zoom,49.2,5.27,0.5,1.1,tzoom,MightyCucumber,FALSE
+Dust Mite,50.5,1.98,1.2,1.2,mite,Acclaim Studios London,TRUE
+Piccino,50.1,3.11,0.85,1.2,midgetii,NotDaijoubu,FALSE
+Phat Slug,50.8,1.41,2.5,1.7,phat,Acclaim Studios London,TRUE
+Shiawase,41.6,1,5,2.0,shiawasecrimsonsolace,shara--,FALSE
+Creeki Leeki,49.9,2.16,1.2,3.0,gtcnd_creekileeki,Ghosterino,FALSE

--- a/models/cars/semi-pro.csv
+++ b/models/cars/semi-pro.csv
@@ -1,36 +1,33 @@
-name,speed,acc,weight,multiplier,folder_name,stock
-Adeon,59.1,2.97,1.2,0.7,adeon,TRUE
-Dragoon,61.2,2.26,2.2,0.7,nrf_dragoon,FALSE
-Sir Racealot,58.2,3.77,1.8,0.7,tcp_camelot,FALSE
-Sokudo,56.3,5.19,1.2,0.7,sokudo,FALSE
-Teacee,59.0,2.98,2.0,0.7,teacee,FALSE
-Toy-World GT,62.4,3.87,1.65,0.7,tcp_twgt,FALSE
-Zipper,60.7,2.82,1.4,0.8,tc1,TRUE
-JG-7,59,2.72,1.2,0.8,jg1jg7,TRUE
-Ancile,58.2,2.29,2.5,0.8,lib6ax_ancile,FALSE
-Gridlock,58.1,2.42,1.4,0.8,tcp_gridlock,FALSE
-Mambra,58.6,4.37,1.6,0.8,mambra,FALSE
-RC-Erra,59.9,2.53,1.6,0.8,cera,FALSE
-Touga,65.7,3.08,2,0.8,touga,FALSE
-Victoria,57.4,2.65,1.7,0.8,phim_victoria,FALSE
-5TP,62.2,3.04,2.5,0.9,jgp_5tp,FALSE
-Chilla,62,2.22,1.4,0.9,tcp_chilla,FALSE
-Ducktail,60.3,2.46,2,0.9,phim_ducktail,FALSE
-M4 Dirtmaster,59.2,2.45,1.9,0.9,fd23m4,FALSE
-Maxam RS,61.1,2.23,1.7,0.9,maxamrs,FALSE
-Runner 2000,59.8,3.18,1.32,0.9,nrf_runner,FALSE
-Sasquatch,61.4,2.47,3,0.9,sasquatch,FALSE
-Speed Balancer,62.1,3.22,1.8,0.9,speedbalancer,FALSE
-RG1,57.9,2.82,1.4,1.0,tc7,TRUE
-Trundle Buster,61.5,2.92,4,1.0,nm_trundle,FALSE
-Ballista,62.5,4.18,2.0,1.2,ballista,FALSE
-Otaku-D,61.3,3.68,1.7,1.2,phim_sileighty,FALSE
-Pemto,65.7,2.58,1.5,1.2,pemto,FALSE
-Sidepod,63.9,2.25,1.2,1.3,sidepod,FALSE
-Big Load,61.5,1.94,3.7,1.5,jgp_bigload,FALSE
-Pest Control,66.6,1.66,2,2.3,tc3,TRUE
-Pole Poz,60.5,2.53,1.7,2.3,fone,TRUE
-Roadkill,64.4,3.53,1.25,2.4,roadkill,FALSE
-Project Octagon,62.5,2.34,1.6,2.5,pm_octa,FALSE
-Rotor,65.3,2.01,3,2.9,rotor,TRUE
-RV Loco,63.6,1.98,2.25,3.2,jg3loco,TRUE
+name,speed,acc,weight,multiplier,folder_name,author,stock
+Adeon,59.1,2.97,1.2,0.7,adeon,Acclaim Studios London,TRUE
+Docta,57.8,4.2,1.2,0.7,docta,TTDriver,FALSE
+Dragoon,61.2,2.26,2.2,0.7,nrf_dragoon,Norfair,FALSE
+Sir Racealot,58.2,3.77,1.8,0.7,tcp_camelot,Xarc,FALSE
+Teacee,59.0,2.98,2.0,0.7,teacee,TTDriver,FALSE
+Touga,65.7,3.08,2,0.7,touga,MightyCucumber,FALSE
+Zipper,60.7,2.82,1.4,0.8,tc1,Acclaim Studios London,TRUE
+JG-7,59,2.72,1.2,0.8,jg1jg7,Acclaim Studios London,TRUE
+Ancile,58.2,2.29,2.5,0.8,lib6ax_ancile,Norfair,FALSE
+Argon,60,3.81,1.3,0.8,gtc_argon,Ghosterino,FALSE
+Mambra,58.6,4.37,1.6,0.8,mambra,MightyCucumber,FALSE
+Yognac,59.8,2.86,1.34,0.8,yognac,Zeino,FALSE
+5TP,62.2,3.04,2.5,0.9,jgp_5tp,Norfair,FALSE
+Chilla,62,2.22,1.4,0.9,tcp_chilla,BloodBTF,FALSE
+Gravel Basher,59.8,2.45,1.2,0.9,gravelbasher,TTDriver,FALSE
+Gridlock,58.1,2.42,1.4,0.9,tcp_gridlock,Norfair,FALSE
+Maxam RS,61.1,2.23,1.7,0.9,maxamrs,BloodBTF,FALSE
+Runner 2000,59.8,3.18,1.32,0.9,nrf_runner,Norfair,FALSE
+Sasquatch,61.4,2.47,3,0.9,sasquatch,kiwi,FALSE
+Speed Balancer,62.1,3.22,1.8,0.9,speedbalancer,TTDriver,FALSE
+RG1,57.9,2.82,1.4,1.0,tc7,Acclaim Studios London,TRUE
+Mosher,60.7,2.37,2,1.0,tcp_metalhead,burner94,FALSE
+Trundle Buster,61.5,2.92,4,1.0,nm_trundle,Paperman,FALSE
+Twenty-M,63.4,2.16,1.2,1.0,tc6super20,burner94,FALSE
+Ballista,62.5,4.18,2.0,1.2,ballista,TTDriver,FALSE
+Pemto,65.7,2.58,1.5,1.2,pemto,kiwi,FALSE
+Big Load,61.5,1.94,3.7,1.5,jgp_bigload,Norfair,FALSE
+Pest Control,66.6,1.66,2,2.3,tc3,Acclaim Studios London,TRUE
+Pole Poz,60.5,2.53,1.7,2.3,fone,Acclaim Studios London,TRUE
+Roadkill,64.4,3.53,1.25,2.5,roadkill,Zeino,FALSE
+Rotor,65.3,2.01,3,2.9,rotor,Acclaim Studios London,TRUE
+RV Loco,63.6,1.98,2.25,3.2,jg3loco,Acclaim Studios London,TRUE

--- a/models/cars/semi-pro.csv
+++ b/models/cars/semi-pro.csv
@@ -1,5 +1,6 @@
 name,speed,acc,weight,multiplier,folder_name,author,stock
 Adeon,59.1,2.97,1.2,0.7,adeon,Acclaim Studios London,TRUE
+Ancile,58.2,2.29,2.5,0.7,lib6ax_ancile,Norfair,FALSE
 Docta,57.8,4.2,1.2,0.7,docta,TTDriver,FALSE
 Dragoon,61.2,2.26,2.2,0.7,nrf_dragoon,Norfair,FALSE
 Sir Racealot,58.2,3.77,1.8,0.7,tcp_camelot,Xarc,FALSE
@@ -7,7 +8,6 @@ Teacee,59.0,2.98,2.0,0.7,teacee,TTDriver,FALSE
 Touga,65.7,3.08,2,0.7,touga,MightyCucumber,FALSE
 Zipper,60.7,2.82,1.4,0.8,tc1,Acclaim Studios London,TRUE
 JG-7,59,2.72,1.2,0.8,jg1jg7,Acclaim Studios London,TRUE
-Ancile,58.2,2.29,2.5,0.8,lib6ax_ancile,Norfair,FALSE
 Argon,60,3.81,1.3,0.8,gtc_argon,Ghosterino,FALSE
 Mambra,58.6,4.37,1.6,0.8,mambra,MightyCucumber,FALSE
 Yognac,59.8,2.86,1.34,0.8,yognac,Zeino,FALSE

--- a/models/cars/super-pro.csv
+++ b/models/cars/super-pro.csv
@@ -1,36 +1,33 @@
-name,speed,acc,weight,multiplier,folder_name,stock
-Armand,69.2,4.17,1.45,0.7,armando,FALSE
-Endo,71.2,4.75,2.7,0.7,nrf_endo,FALSE
-Phantera ART,72.9,3.59,1.75,0.7,phanteraart,FALSE
-Raven,70.4,3.5,2.5,0.7,raven,FALSE
-Revolution 12,71.4,4.48,1.8,0.7,gtc_revolution12,FALSE
-Wyvern,70.7,3.81,1.8,0.7,tcp_wyvern,FALSE
-Calcure,71.2,2.87,2,0.8,phim_calcure,FALSE
-Cambold R,71.1,3.69,1.4,0.8,camboldr,FALSE
-Commandine,65.1,3.44,2,0.8,fd101command,FALSE
-Daemmon,74.6,3.86,1.85,0.8,daemmon,FALSE
-La Rossa,73,4.14,2,0.8,fd94rossa,FALSE
-Powerpython,70.3,3.53,2,0.8,tcp_python,FALSE
-Prototype FX77,65.3,2.98,1.2,0.8,fd_s9,FALSE
-RVRC,70.3,4,2,0.8,rvrc,FALSE
-Spedion,69.5,4.13,2,0.8,phim_jgspedion,FALSE
-Starmac,68.7,3.54,1.8,0.8,starmac,FALSE
-Tesseract,71.5,4.02,2,0.8,fd_s7,FALSE
-Vanguard,73.8,5.11,1.6,0.8,vanguard,FALSE
-XM250,70.4,3.13,1.4,0.8,xm250,FALSE
-Disruption,67.9,3.52,3,0.9,tcp_disruption,FALSE
-Gungnir,67.9,3.46,3.3,0.9,gungnir,FALSE
-Madax GT,71.6,2.75,2.15,0.9,fzg_madax,FALSE
-Nahesa,71.4,3.62,1.6,0.9,yun_nahesa,FALSE
-Nakajima,76.2,3.2,1.25,0.9,nakajima,FALSE
-Voltrex,72.8,3.88,1.3,0.9,moz_voltrex,FALSE
-FLIR,71.4,5.66,2,1.0,nrf_flir,FALSE
-King Kaiju,72.7,4.4,1.75,1.0,tx11kaiju,FALSE
-King Moloko,77.3,3.04,2.7,1.0,kingmoloko,FALSE
-Megalodon XL,77.3,3.74,2.2,1.0,megalodonxl,FALSE
-Saeger,71.5,5.8,2,1.0,saeger,FALSE
-Forged Steel,71.5,3.19,2.2,1.1,tcp_forge,FALSE
-Rinne,80.6,3.69,1.9,1.1,rinne,FALSE
-Identity X,78.3,3.38,2.5,1.2,fd95x,FALSE
-Napalm,76.1,5.43,2,1.4,fd_s21,FALSE
-Oblitenitro,83.5,2.38,3.5,1.5,oblitenitro,FALSE
+name,speed,acc,weight,multiplier,folder_name,author,stock
+Endo,71.2,4.75,2.7,0.7,nrf_endo,Norfair,FALSE
+Phantera ART,72.9,3.59,1.75,0.7,phanteraart,FZG (Ziggy),FALSE
+Raven,70.4,3.5,2.5,0.7,raven,Norfair,FALSE
+Revolution 12,71.4,4.48,1.8,0.7,gtc_revolution12,Ghosterino,FALSE
+Wyvern,70.7,3.81,1.8,0.7,tcp_wyvern,Norfair,FALSE
+Alter,70.4,3.02,2.5,0.8,alter,TTDriver,FALSE
+Calcure,71.2,2.87,2,0.8,phim_calcure,Phimeek,FALSE
+Commandine,65.1,3.44,2,0.8,fd101command,Xarc,FALSE
+La Rossa,73,4.14,2,0.8,fd94rossa,Xarc,FALSE
+RVRC,70.3,4,2,0.8,rvrc,Xarc,FALSE
+Spedion,69.5,4.13,2,0.8,phim_jgspedion,Phimeek,FALSE
+Starmac,68.7,3.54,1.8,0.8,starmac,MightyCucumber,FALSE
+Tesseract,71.5,4.02,2,0.8,fd_s7,Xarc,FALSE
+XM250,70.4,3.13,1.4,0.8,xm250,Norfair,FALSE
+Argon Auto,71.5,4.3,1.8,0.9,tcp_argon,MightyCucumber,FALSE
+Disruption,67.9,3.52,3,0.9,tcp_disruption,Norfair,FALSE
+Gungnir,67.9,3.46,3.3,0.9,gungnir,TTDriver,FALSE
+Madax GT,71.6,2.75,2.15,0.9,fzg_madax,FZG (Ziggy),FALSE
+Nahesa,71.4,3.62,1.6,0.9,yun_nahesa,yun,FALSE
+Nakajima,76.2,3.2,1.25,0.9,nakajima,burner94,FALSE
+Voltrex,72.8,3.88,1.3,0.9,moz_voltrex,MightyCucumber,FALSE
+FLIR,71.4,5.66,2,1.0,nrf_flir,Norfair,FALSE
+Ilmenite,73.8,3.22,3.5,1.0,yun_ilmenite,yun,FALSE
+King Kaiju,72.7,4.4,1.75,1.0,tx11kaiju,Trixed,FALSE
+King Moloko,77.3,3.04,2.7,1.0,kingmoloko,kiwi,FALSE
+Megalodon XL,77.3,3.74,2.2,1.0,megalodonxl,Norfair,FALSE
+Saeger,71.5,5.8,2,1.0,saeger,Skarma,FALSE
+Petty,73.6,2.87,1.7,1.1,gtc_petty,Ghosterino,FALSE
+Rinne,80.6,3.69,1.9,1.1,rinne,Xarc,FALSE
+Identity X,78.3,3.38,2.5,1.2,fd95x,Xarc,FALSE
+Napalm,76.1,5.43,2,1.4,fd_s21,Xarc,FALSE
+Oblitenitro,83.5,2.38,3.5,1.5,oblitenitro,FZG (Ziggy),FALSE


### PR DESCRIPTION
**Rookie:** 
- IN: Cheat Code Central, Mr Bedtime, Beeble, Turbo Katto, Toon Zoom.
- OUT: Iso-77A, Kanberra Kruiser, Bed Bug, El Gekko, Hot Spot, Gunior, Super Wheat, HSF-1.

**Amateur:** 
- IN: Downforce, Fun Zone, Lineage, Moffat Snake, Tin Lizzie.
- OUT: Honeybee, Vixen, Ashley, Sugar N' Spice, Muller GT, Stonemason, Phantum, Six Shooter.

**Advanced:** 
- IN: Alpina XL, Breaker, Exert, Looper, Moonshine XL.
- OUT: Alice, Neifion, Camelia, Nano Rascal, Rice Ball, XTAR, Hyper XL, Donnie TC.

**Semi-Pro:**
- IN: Argon, Docta, Gravel Basher, Mosher, Twenty-M, Yognac.
- OUT: Sokudo, Toy-World GT, RC-Erra, Victoria, Ducktail, M4 Dirtmaster, Otaku-D, Sidepod, Project Octagon.
- Balance changes: Gridlock (0.8 -> 0.9), Touga (0.8 -> 0.7), Gridlock (2.4 -> 2.5).

**Pro:**
- IN: Broadley, Ektoplazm, Giga Chief, Invictus, Roadzilla, Spettrale.
- OUT: Abomin8r, Drome Champ, Sin, Burning Steel, Dasher TC, Karen, Tegelhus, Truckenstein, Star Oil.

**Super Pro:**
- IN: Alter, Argon Auto, Ilmenite, Petty.
- OUT: Armand, Cambold R, Daemmon, Powerpython, Prototype FX77, Vanguard, Forged Steel.