### PR TITLE
Cars Update Season 2024 - 4th Ranking

### DIFF
--- a/models/cars/advanced.csv
+++ b/models/cars/advanced.csv
@@ -21,8 +21,8 @@ YNZ,58.7,2.16,1.7,0.9,nrf_ynz,Norfair,FALSE
 Panga TC,59.9,2.13,1.8,1.0,tc2,Acclaim Studios London,TRUE
 Shocker,57.2,2.13,1.8,1.0,tc8,Acclaim Studios London,TRUE
 Diamond,55.9,2.23,1.2,1.0,diamond,TTDriver,FALSE
-Exert,60.4,2.37,1.25,1.0,exert,burner94,FALSE
 Metal Masher,53.4,2.59,2.7,1.0,jgp_metalmasher,Ghosterino,FALSE
+Northonda,57.2,3,1.6,1.0,gtc_northonda,Ghosterino,FALSE
 Flower Power,57.8,2.76,1.6,1.1,flowerpower2,MightyCucumber,FALSE
 Panther,62.9,2.18,1.65,1.1,panthergto,kiwi,FALSE
 BossVolt,57.4,2.16,3.5,1.2,bossvolt,Acclaim Studios London,TRUE

--- a/models/cars/amateur.csv
+++ b/models/cars/amateur.csv
@@ -1,26 +1,26 @@
 name,speed,acc,weight,multiplier,folder_name,author,stock
-RC San,53.3,3.17,1,0.7,dino,Acclaim Studios London,TRUE
 Aquasonic,55.1,2.42,1.4,0.7,tc4,Acclaim Studios London,TRUE
-Outraga,53.8,2.42,1.35,0.7,fd46rage,Xarc,FALSE
+RC San,53.3,3.17,1,0.7,dino,Acclaim Studios London,TRUE
 Rad Signal,52.4,2.64,1.2,0.7,tcp_doh,Norfair,FALSE
+Radscoop,52.9,2.17,2,0.7,radscoop,TTDriver,FALSE
 RC Halo,52.9,2.19,1.9,0.7,tcp_homage,Trixed,FALSE
 Smokie,58.2,2.41,1.6,0.7,smokie,kiwi,FALSE
 LA 54,52,2.52,1.2,0.8,tc12,Acclaim Studios London,TRUE
 Matra XL,55.8,2.12,1.4,0.8,tc10,Acclaim Studios London,TRUE
 AMCO TC,51.2,2.3,3.7,0.8,amcotc,Zeino,FALSE
 Bumblebee,50.4,2.28,1.1,0.8,bumblebee,kiwi,FALSE
+D-Maxx,52.1,2.18,2,0.8,dmaxx,TTDriver,FALSE
 Ignit-9,51.9,2.3,1.5,0.8,lib9a_ignit,Paperman,FALSE
 LMW,56.1,1.74,2,0.8,nrf_lmw,Norfair,FALSE
-Lineage,52.3,1.95,2.5,0.8,lineage,BrotatoTheBadassSpud,FALSE
 Locker,52.1,2.98,1.4,0.8,tclock,BloodBTF,FALSE
 Moffat Snake,50.4,2.31,1.3,0.8,moffat,Trixed,FALSE
+Stompy,51.1,2.42,0.7,0.8,stompy,TTDriver,FALSE
 Candy Pebbles,55.3,1.83,1.3,0.9,candy,Acclaim Studios London,TRUE
 Baja Dash,49.9,2.52,2,0.9,lib8a_dash,Norfair,FALSE
 Fun Zone,53.7,2.28,1.3,0.9,tcp_party,MightyCucumber,FALSE
 Kyarus,52.2,3.15,1.3,0.9,kyarus,MightyCucumber,FALSE
 Mongoose,53.1,2,1.4,0.9,mongoose,Norfair,FALSE
 Strax,50.4,2.58,1.4,0.9,strax,kiwi,FALSE
-The Rook,55.3,1.93,1.3,0.9,tcp_rook,Trixed,FALSE
 Tin Lizzie,55,2.71,0.7,0.9,tinlizzie,Zeino,FALSE
 X-6 Nitro,51.8,2.3,1.6,0.9,jgp_x6,Ghosterino,FALSE
 Mouse,54.7,2.9,2.3,1.0,mouse,Acclaim Studios London,TRUE

--- a/models/cars/pro.csv
+++ b/models/cars/pro.csv
@@ -4,8 +4,8 @@ SNW 35,65.8,4.32,1.5,0.7,jg4snw35,Acclaim Studios London,TRUE
 Toyeca,64.8,3.2,2,0.7,toyeca,Acclaim Studios London,TRUE
 Outlaw,66.2,2.62,2,0.7,nrf_outlaw,Norfair,FALSE
 Ridgeback,65.6,3.3,1.9,0.7,ridgeback,Norfair,FALSE
-Ryu,64.1,3.33,1.5,0.7,ryu,Trixed,FALSE
 Spettrale,63.8,4.88,2,0.7,phim_spettrale,Phimeek,FALSE
+Blackfang,66.6,2.9,2,0.8,blackfangr8,Paddy Productions,FALSE
 Chimera TC,61.4,3.73,1.6,0.8,chimtc,BloodBTF,FALSE
 Puma,64.5,4.14,1.8,0.8,nrf_puma,Norfair,FALSE
 Roadzilla,65.4,4.85,1.66,0.8,tcp_rex,MightyCucumber,FALSE
@@ -14,15 +14,15 @@ Humma,64,3.45,2,0.9,sugo,Acclaim Studios London,TRUE
 Acclaim F1,66.8,3.66,1.0,0.9,acclaimf1,MightyCucumber,FALSE
 Invictus,66.1,3.25,2,0.9,victus,Trixed,FALSE
 Steezy,66,3.07,1.7,0.9,steezy,Norfair,FALSE
+Sunrise,66.5,2.92,1.9,0.9,nrf_sunrise,Norfair,FALSE
 Visconti R,63.2,3.43,1.8,0.9,visconti,burner94,FALSE
-Y Force,67.2,2.73,2,0.9,fd158yforce,Xarc,FALSE
 Giga Chief,69.1,2.3,2.7,1.0,gtc_gigachief,Ghosterino,FALSE
 Polar Star,64.5,2.11,1.5,1.0,gtc_polarstar,Ghosterino,FALSE
+Ristretto,62.9,3.53,1.3,1.0,jgp_ristretto,TTDriver,FALSE
 Sucker Punch,66.6,3.18,1.25,1.0,fan,burner94,FALSE
 Wildstar,66.3,3.6,1,1.0,wildstar,TTDriver,FALSE
-Broadley,69.2,2.21,1.7,1.1,gtc_broadley,Ghosterino,FALSE
 Patriot,73.7,5.04,1.9,1.1,patriot,MightyCucumber,FALSE
-Toro GT84,70.4,2.92,1.5,1.1,gt84,Flo,FALSE
+Ultra Drive,67.9,4.11,1.8,1.1,ultradrive,TTDriver,FALSE
 Ektoplazm,68.7,4.58,1.5,1.2,tcp_ekto,Trixed,FALSE
 Sir Gleam,67.4,4.45,1,1.2,gleam,MightyCucumber,FALSE
 RC Bulldog,70.5,2.81,5,1.3,bulldog,Trixed,FALSE

--- a/models/cars/super-pro.csv
+++ b/models/cars/super-pro.csv
@@ -16,7 +16,7 @@ Alter,70.4,3.02,2.5,0.9,alter,TTDriver,FALSE
 Argon Auto,71.5,4.3,1.8,0.9,tcp_argon,MightyCucumber,FALSE
 Disruption,67.9,3.52,3,0.9,tcp_disruption,Norfair,FALSE
 Gungnir,67.9,3.46,3.3,0.9,gungnir,TTDriver,FALSE
-Madax GT,71.6,2.75,2.15,0.9,fzg_madax,FZG (Ziggy),FALSE
+Hoshino,75.7,3.24,2,0.9,hoshino,burner94,FALSE
 Nahesa,71.4,3.62,1.6,0.9,yun_nahesa,yun,FALSE
 Nakajima,76.2,3.2,1.25,0.9,nakajima,burner94,FALSE
 Voltrex,72.8,3.88,1.3,0.9,moz_voltrex,MightyCucumber,FALSE
@@ -27,7 +27,7 @@ Megalodon XL,77.3,3.74,2.2,1.0,megalodonxl,Norfair,FALSE
 Saeger,71.5,5.8,2,1.0,saeger,Skarma,FALSE
 Identity X,78.3,3.38,2.5,1.1,fd95x,Xarc,FALSE
 Rinne,80.6,3.69,1.9,1.1,rinne,Xarc,FALSE
-Ilmenite,73.8,3.22,3.5,1.4,yun_ilmenite,yun,FALSE
+Ilmenite,75.0,3.94,3.5,1.4,yun_ilmenite,yun,FALSE
 Napalm,76.1,5.43,2,1.4,fd_s21,Xarc,FALSE
 Oblitenitro,83.5,2.38,3.5,1.5,oblitenitro,FZG (Ziggy),FALSE
 Petty,73.6,2.87,1.7,2.0,gtc_petty,Ghosterino,FALSE


### PR DESCRIPTION
Amateur
- Radscoop (0.7) -> Outraga
- D-Maxx (0.8) -> The Rook
- Stompy (0.8) -> Lineage

Advanced
- Northonda (1.0) -> Exert

Pro
- Blackfang (0.8) -> Ryu
- Invictus (Updated stats)
- Sunrise (0.9) -> Y Force
- Ristretto (1.0) -> Broadley
- Ultra Drive (1.1) -> Toro GT84

Super Pro
- Hoshino (0.9) -> Madax GT
- Ilmenite (Updated stats)